### PR TITLE
Fix which token is used to checkout gcss config repo

### DIFF
--- a/.github/workflows/promote-imported-configs.yaml
+++ b/.github/workflows/promote-imported-configs.yaml
@@ -19,8 +19,6 @@ on:
     secrets:
       app_private_key:
         required: true
-      gh_token:
-        required: true
       tfc_token:
         required: true
 
@@ -50,7 +48,7 @@ jobs:
         uses: ./.github/actions/gcss-config-setup
         with:
           checkout-sha: ${{ inputs.commit_sha }}
-          checkout-token: ${{ secrets.gh_token }}
+          checkout-token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup terraform and run plan
         id: graformer


### PR DESCRIPTION
This PR fixes which token is used to checkout GCSS config repo. It should use the token from the generate token step instead of default GHA token