### PR TITLE
Support workflow build type for GitHub Pages

### DIFF
--- a/.schemas/repository-config.schema.json
+++ b/.schemas/repository-config.schema.json
@@ -144,7 +144,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "branch",
         "build_type"
       ]
     },

--- a/DEVELOPERS_GUIDE.md
+++ b/DEVELOPERS_GUIDE.md
@@ -136,15 +136,15 @@ Options for configuring a repository from a template.
 
 Options for configuring GitHub Pages.
 
+- **`build_type`**: *(required, string)* The build type for GitHub Pages. Possible values:
+  - `workflow` - Pages are deployed via a GitHub Actions workflow. Only `cname` and `build_type` are required; `branch` and `path` must not be set.
+  - `legacy` - Pages are deployed from a branch. `branch` is required in addition to `build_type`.
+
 - **`cname`**: *(optional, string)* The custom domain for GitHub Pages.
 
-- **`branch`**: *(required, string)* The branch to use for GitHub Pages.
+- **`branch`**: *(required when `build_type` is `legacy`, string)* The branch to use for GitHub Pages.
 
-- **`path`**: *(optional, string)* The directory path for GitHub Pages content.
-
-- **`build_type`**: *(required, string)* The build type for GitHub Pages. Possible values:
-  - `workflow` - For deploying pages by Github Actions workflow
-  - `legacy` - For manual deployment using the `gh-pages` branch
+- **`path`**: *(optional, string)* The directory path for GitHub Pages content. Only applicable when `build_type` is `legacy`.
 
 ## Ruleset Configuration
 

--- a/feature/github-repo-importer/pkg/github/github.go
+++ b/feature/github-repo-importer/pkg/github/github.go
@@ -655,15 +655,18 @@ func resolveActorName(actor *github.BypassActor, roleActors map[int64]string, te
 }
 
 func resolvePages(pages *github.Pages) *Pages {
-	if pages != nil {
-		return &Pages{
-			CNAME:     pages.CNAME,
-			Branch:    pages.GetSource().Branch,
-			Path:      pages.GetSource().Path,
-			BuildType: pages.BuildType,
-		}
+	if pages == nil {
+		return nil
 	}
-	return nil
+	resolved := &Pages{
+		CNAME:     pages.CNAME,
+		BuildType: pages.BuildType,
+	}
+	if pages.GetBuildType() != "workflow" {
+		resolved.Branch = pages.GetSource().Branch
+		resolved.Path = pages.GetSource().Path
+	}
+	return resolved
 }
 
 func resolveRepositoryTemplate(githubRepository *github.Repository) *RepositoryTemplate {

--- a/feature/github-repo-importer/pkg/github/github_test.go
+++ b/feature/github-repo-importer/pkg/github/github_test.go
@@ -258,18 +258,32 @@ func TestResolvePages(t *testing.T) {
 		expected *Pages
 	}{
 		{
-			name: "valid pages configuration",
+			name: "legacy build type includes branch and path",
 			input: &github.Pages{
-				CNAME: github.String("example.com"),
+				CNAME:     github.String("example.com"),
+				BuildType: github.String("legacy"),
 				Source: &github.PagesSource{
 					Branch: github.String("gh-pages"),
 					Path:   github.String("/docs"),
 				},
 			},
 			expected: &Pages{
-				CNAME:  github.String("example.com"),
-				Branch: github.String("gh-pages"),
-				Path:   github.String("/docs"),
+				CNAME:     github.String("example.com"),
+				BuildType: github.String("legacy"),
+				Branch:    github.String("gh-pages"),
+				Path:      github.String("/docs"),
+			},
+		},
+		{
+			name: "workflow build type omits branch and path",
+			input: &github.Pages{
+				CNAME:     github.String("example.com"),
+				BuildType: github.String("workflow"),
+				Source:    &github.PagesSource{},
+			},
+			expected: &Pages{
+				CNAME:     github.String("example.com"),
+				BuildType: github.String("workflow"),
 			},
 		},
 		{

--- a/feature/github-repo-importer/pkg/github/repositories.go
+++ b/feature/github-repo-importer/pkg/github/repositories.go
@@ -54,7 +54,7 @@ type RepositoryTemplate struct {
 
 type Pages struct {
 	CNAME     *string `yaml:"cname,omitempty"`
-	Branch    *string `yaml:"branch,omitempty" jsonschema:"required"`
+	Branch    *string `yaml:"branch,omitempty"`
 	Path      *string `yaml:"path,omitempty"`
 	BuildType *string `yaml:"build_type,omitempty" jsonschema:"required,enum=workflow,enum=legacy"`
 }

--- a/feature/github-repo-provisioning/main.tf
+++ b/feature/github-repo-provisioning/main.tf
@@ -181,8 +181,8 @@ module "repository" {
   topics                  = try(each.value.topics,                  [])
   archive_on_destroy      = try(each.value.archive_on_destroy,      null)
   pages                   = try(contains(keys(each.value), "pages") && try(each.value.pages != null, false) ? {
-                              branch      = try(each.value.pages.branch, "gh-pages")
-                              path        = try(each.value.pages.path,   "/")
+                              branch      = try(each.value.pages.build_type, null) == "workflow" ? null : try(each.value.pages.branch, "gh-pages")
+                              path        = try(each.value.pages.build_type, null) == "workflow" ? null : try(each.value.pages.path, "/")
                               cname       = try(each.value.pages.cname,  null)
                               build_type  = try(each.value.pages.build_type,  null)
                             } : null)

--- a/feature/github-repo-provisioning/modules/terraform-github-repository/README.md
+++ b/feature/github-repo-provisioning/modules/terraform-github-repository/README.md
@@ -21,6 +21,7 @@ This module is a **vendored version** of the original Terraform module from [min
 - Improved handling of null values with the `try` function.
 - Changed default values for `enforce_admins`, `require_code_owner_reviews`, and `dismiss_stale_reviews`.
 - Fixed handling of blocks `required_status_checks`, `required_pull_request_reviews` and `restrict_pushes`
+- Made `pages.source` block conditional — it is omitted when `pages.build_type` is `workflow`, as branch and path are not required in that case.
 
 These changes enhance flexibility and allow for more granular control over branch protection rules.
 

--- a/feature/github-repo-provisioning/modules/terraform-github-repository/main.tf
+++ b/feature/github-repo-provisioning/modules/terraform-github-repository/main.tf
@@ -136,9 +136,12 @@ resource "github_repository" "repository" {
 
     content {
       build_type = var.pages.build_type
-      source {
-        branch = var.pages.branch
-        path   = try(var.pages.path, "/")
+      dynamic "source" {
+        for_each = try(var.pages.build_type, null) != "workflow" ? [true] : []
+        content {
+          branch = var.pages.branch
+          path   = try(var.pages.path, "/")
+        }
       }
       cname = try(var.pages.cname, null)
     }


### PR DESCRIPTION
When `pages.build_type` is "workflow", branch and path are not required by the GitHub API. This change omits the source block in the Terraform module and skips setting branch/path in the importer for workflow builds.