### PR TITLE
Switch to G-Research-Forks/github provider

### DIFF
--- a/feature/github-repo-provisioning/backend.tf.hcp
+++ b/feature/github-repo-provisioning/backend.tf.hcp
@@ -5,8 +5,8 @@ terraform {
 
   required_providers {
     github = {
-      source = "G-Research/github"
-      version = "6.9.0-gr.2"
+      source = "G-Research-Forks/github"
+      version = "6.9.0-gr.3"
     }
   }
 }

--- a/feature/github-repo-provisioning/backend.tf.local
+++ b/feature/github-repo-provisioning/backend.tf.local
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     github = {
-      source = "G-Research/github"
-      version = "6.9.0-gr.2"
+      source = "G-Research-Forks/github"
+      version = "6.9.0-gr.3"
     }
   }
 }

--- a/feature/github-repo-provisioning/modules/terraform-github-repository/versions.tf
+++ b/feature/github-repo-provisioning/modules/terraform-github-repository/versions.tf
@@ -7,8 +7,8 @@ terraform {
 
   required_providers {
     github = {
-      source = "G-Research/github"
-      version = "6.9.0-gr.2"
+      source = "G-Research-Forks/github"
+      version = "6.9.0-gr.3"
     }
   }
 }


### PR DESCRIPTION
Switch to G-Research-Forks/github provider as it is moved there. Use gr.3 version, it's the same as gr.2 just signed for new namespace. I did this in case that checksum issue is reflected in the GRF namespace, so we are safe