### PR TITLE
security: pin GitHub Actions references to commit SHAs

### DIFF
--- a/.github/actions/gcss-config-setup/action.yaml
+++ b/.github/actions/gcss-config-setup/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout configuration repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       with:
         path: feature/github-repo-provisioning/gcss_config
         ref: ${{ inputs.checkout-sha }}

--- a/.github/actions/gcss-config-setup/action.yaml
+++ b/.github/actions/gcss-config-setup/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout configuration repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         path: feature/github-repo-provisioning/gcss_config
         ref: ${{ inputs.checkout-sha }}

--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       with:
         cli_config_credentials_token: ${{ inputs.tfc-token }}
 
@@ -86,7 +86,7 @@ runs:
         }' > tfplan.json
 
     - name: Inspect plan result
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       id: inspect-plan-result
       with:
         script: |

--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
       with:
         cli_config_credentials_token: ${{ inputs.tfc-token }}
 
@@ -86,7 +86,7 @@ runs:
         }' > tfplan.json
 
     - name: Inspect plan result
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
       id: inspect-plan-result
       with:
         script: |

--- a/.github/workflows/bulk-import.yaml
+++ b/.github/workflows/bulk-import.yaml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -30,7 +30,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
@@ -43,7 +43,7 @@ jobs:
           checkout-token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
         with:
           just-version: '1.4.0'
 

--- a/.github/workflows/bulk-import.yaml
+++ b/.github/workflows/bulk-import.yaml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -30,7 +30,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
@@ -43,7 +43,7 @@ jobs:
           checkout-token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
         with:
           just-version: '1.4.0'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
         working-directory: feature/github-repo-importer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: feature/github-repo-importer/go.mod
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
         working-directory: feature/github-repo-importer
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: feature/github-repo-importer/go.mod
 

--- a/.github/workflows/create-fork.yaml
+++ b/.github/workflows/create-fork.yaml
@@ -30,7 +30,7 @@ jobs:
     environment: create-fork
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Parse and validate input
         id: parse-upstream
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           UPSTREAM_REPO: ${{ inputs.upstream_repo }}
           FORK_NAME: ${{ inputs.fork_name }}

--- a/.github/workflows/create-fork.yaml
+++ b/.github/workflows/create-fork.yaml
@@ -30,7 +30,7 @@ jobs:
     environment: create-fork
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Parse and validate input
         id: parse-upstream
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           UPSTREAM_REPO: ${{ inputs.upstream_repo }}
           FORK_NAME: ${{ inputs.fork_name }}

--- a/.github/workflows/drift-check.yaml
+++ b/.github/workflows/drift-check.yaml
@@ -24,7 +24,7 @@ jobs:
     environment: schedule
     steps:
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/drift-check.yaml
+++ b/.github/workflows/drift-check.yaml
@@ -24,7 +24,7 @@ jobs:
     environment: schedule
     steps:
       - name: Checkout GCSS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -27,7 +27,7 @@ jobs:
     environment: import
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -35,7 +35,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
@@ -48,7 +48,7 @@ jobs:
           checkout-token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
         with:
           just-version: '1.4.0'
 

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -27,7 +27,7 @@ jobs:
     environment: import
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -35,7 +35,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
@@ -48,7 +48,7 @@ jobs:
           checkout-token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
         with:
           just-version: '1.4.0'
 

--- a/.github/workflows/promote-imported-configs.yaml
+++ b/.github/workflows/promote-imported-configs.yaml
@@ -34,7 +34,7 @@ jobs:
       contents: write
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -42,7 +42,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/promote-imported-configs.yaml
+++ b/.github/workflows/promote-imported-configs.yaml
@@ -34,7 +34,7 @@ jobs:
       contents: write
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -42,7 +42,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout GCSS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -41,7 +41,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Create in-progress check-run
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
         with:
@@ -63,7 +63,7 @@ jobs:
               });
 
       - name: Checkout GCSS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Post plan summary and handle check-run
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           PLAN_SUMMARY: ${{ steps.graformer.outputs.plan-summary }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -41,7 +41,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Create in-progress check-run
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
         with:
@@ -63,7 +63,7 @@ jobs:
               });
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Post plan summary and handle check-run
         if: always()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PLAN_SUMMARY: ${{ steps.graformer.outputs.plan-summary }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions references in this repo to 40-character commit SHAs, replacing tag and branch references. This is a supply-chain hardening change with no expected functional impact — every SHA was resolved from its current tag/branch at audit time (2026-05-27).

## Why

Tag-pinned actions can be silently compromised if the upstream tag is rotated to a malicious commit. Branch-pinned actions (e.g. `@main`, `@release/v1`, `@stable`) are even riskier — anyone with push access upstream can change what runs in CI.

GitHub's own recommendation: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Notes

- Branch-pinned refs (`@main`, `@release/v1`, `@stable`) were resolved to the branch HEAD at audit time — re-verify before merge if the upstream branch has moved since.
- Part of an org-wide audit covering 26 G-Research repos. The full pinning plan and resolved SHAs are tracked in a local audit project.
- No functional change is expected; CI should pass identically.