### PR TITLE
ci: bump node20 actions for node24 cutover

### DIFF
--- a/.github/actions/gcss-config-setup/action.yaml
+++ b/.github/actions/gcss-config-setup/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout configuration repo
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         path: feature/github-repo-provisioning/gcss_config
         ref: ${{ inputs.checkout-sha }}

--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -86,7 +86,7 @@ runs:
         }' > tfplan.json
 
     - name: Inspect plan result
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       id: inspect-plan-result
       with:
         script: |

--- a/.github/workflows/bulk-import.yaml
+++ b/.github/workflows/bulk-import.yaml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -30,7 +30,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         working-directory: feature/github-repo-importer
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/create-fork.yaml
+++ b/.github/workflows/create-fork.yaml
@@ -30,7 +30,7 @@ jobs:
     environment: create-fork
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Parse and validate input
         id: parse-upstream
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           UPSTREAM_REPO: ${{ inputs.upstream_repo }}
           FORK_NAME: ${{ inputs.fork_name }}

--- a/.github/workflows/drift-check.yaml
+++ b/.github/workflows/drift-check.yaml
@@ -24,7 +24,7 @@ jobs:
     environment: schedule
     steps:
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -27,7 +27,7 @@ jobs:
     environment: import
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -35,7 +35,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/promote-imported-configs.yaml
+++ b/.github/workflows/promote-imported-configs.yaml
@@ -34,7 +34,7 @@ jobs:
       contents: write
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -42,7 +42,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Generate a token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -41,7 +41,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Create in-progress check-run
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
         with:
@@ -63,7 +63,7 @@ jobs:
               });
 
       - name: Checkout GCSS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}


### PR DESCRIPTION
GitHub forces `using: node20` JS actions to Node 24 on 2026-06-02. Bumping the affected pins across 8 workflows and 2 composite actions to the lowest tag that declares `using: node24`.

- `actions/checkout`: v4.3.1 → v5.0.1
- `actions/create-github-app-token`: v2.2.2 → v3.2.0 *(v2 is still node20)*
- `actions/github-script`: v7.1.0 → v8.0.0

Note: `tf-plan.yaml` already had `actions/github-script@v8` at one call site (the SHA on `v8` is node24); that one stays. Only the v7 site is bumped.

This callee repo is the upstream for several reusable workflows consumed by [github-configuration](https://github.com/G-Research/github-configuration). The reusable-workflow `uses:` from that repo continues to point at `@v0.2.5` (annotated tag, not a JS action — out of scope for the node20 forcing).