### PR TITLE
Improve Terraform plan check summaries

### DIFF
--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -133,12 +133,13 @@ jobs:
               const importCount = planSummary.import?.length || 0;
               const createCount = (planSummary.create?.length || 0) + recreateCount;
               const deleteCount = (planSummary.delete?.length || 0) + recreateCount;
+              const planResultSummary = `${importCount} to import, ${createCount} to add, ${updateCount} to change, ${deleteCount} to destroy`;
             
               // build body dynamically. indentation inside if statements is important because if text is indented as it should be (4 spaces), it will be rendered as code block in markdown
               body = `
               ### Terraform Plan Result
               
-              Terraform plan: ${importCount} to import, ${createCount} to add, ${updateCount} to change, ${deleteCount} to destroy.
+              Terraform plan: ${planResultSummary}.
               `;
                 
               if (deleteCount > 0) {
@@ -197,12 +198,12 @@ jobs:
             
               switch (process.env.PLAN_EXITCODE) {
                 case "0":      
-                  title = "Terraform Plan Succeeded (no changes)";
+                  title = "Terraform plan: no changes";
                   summary = `Terraform executed successfully with **no changes** required. Please check workflow logs for details: ${detailsUrl}`;
                   text = "No infrastructure changes detected";
                   break;
                 case "2":
-                  title = "Terraform Plan Succeeded (with changes)";
+                  title = `Terraform plan: ${planResultSummary}`;
                   summary = `Terraform executed successfully and **changes are required**. Please check workflow logs for details: ${detailsUrl}`;
                   text = body;
                   if (text.length > 65535) {


### PR DESCRIPTION
## Summary

- reuse the computed Terraform plan counts for the check output title
- show `Terraform plan: no changes` for empty plans
- show import, add, change, and destroy counts for plans with changes

The check-run name remains `Terraform plan`, so existing required-check configuration continues to work.

Fixes #16.

## Remote Linux validation

- `git diff --check`
- parsed `.github/workflows/tf-plan.yaml` with Ruby YAML
- extracted the `Post plan summary and handle check-run` GitHub Script and syntax-checked it with `node --check`
- executed that script under a mocked GitHub context and verified the completed titles for empty and changed plans