### PR TITLE
GCSS-1167: handle import errors

### DIFF
--- a/feature/github-repo-importer/Justfile
+++ b/feature/github-repo-importer/Justfile
@@ -1,5 +1,6 @@
 import-repo repoName:
   #!/usr/bin/env bash
+  set -euo pipefail
   go run main.go import {{repoName}}
   IFS='/' read -r owner repo <<< {{repoName}}
   mkdir -p "../../feature/github-repo-provisioning/gcss_config/importer_tmp_dir/"

--- a/feature/github-repo-importer/cmd/import.go
+++ b/feature/github-repo-importer/cmd/import.go
@@ -20,7 +20,7 @@ var importCmd = &cobra.Command{
 
 		repo, err := github.ImportRepo(repository)
 		if err != nil {
-			return fmt.Errorf("failed to import repo: %w", err)
+			return err
 		}
 
 		if err := github.WriteRepositoryToYaml(repo); err != nil {

--- a/feature/github-repo-importer/cmd/root.go
+++ b/feature/github-repo-importer/cmd/root.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -9,11 +11,27 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "importer",
 	Short: "A CLI tool to fetch GitHub repository details, branch protection rules & rulesets",
+	// Don't dump command usage/help on runtime errors — they bury the real
+	// message. We print errors ourselves in Execute below.
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		// Surface a clean annotation in the GitHub Actions UI/run summary.
+		// https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			fmt.Printf("::error::%s\n", escapeAnnotation(err.Error()))
+		}
 		os.Exit(1)
 	}
+}
+
+// escapeAnnotation escapes a message for use in a GitHub Actions workflow command.
+func escapeAnnotation(s string) string {
+	r := strings.NewReplacer("%", "%25", "\r", "%0D", "\n", "%0A")
+	return r.Replace(s)
 }

--- a/feature/github-repo-importer/cmd/root.go
+++ b/feature/github-repo-importer/cmd/root.go
@@ -9,10 +9,8 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "importer",
-	Short: "A CLI tool to fetch GitHub repository details, branch protection rules & rulesets",
-	// Don't dump command usage/help on runtime errors — they bury the real
-	// message. We print errors ourselves in Execute below.
+	Use:           "importer",
+	Short:         "A CLI tool to fetch GitHub repository details, branch protection rules & rulesets",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }
@@ -20,11 +18,9 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		// Surface a clean annotation in the GitHub Actions UI/run summary.
-		// https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+		_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
 		if os.Getenv("GITHUB_ACTIONS") == "true" {
-			fmt.Printf("::error::%s\n", escapeAnnotation(err.Error()))
+			_, _ = fmt.Fprintf(os.Stdout, "::error::%s\n", escapeAnnotation(err.Error()))
 		}
 		os.Exit(1)
 	}

--- a/feature/github-repo-importer/cmd/root_test.go
+++ b/feature/github-repo-importer/cmd/root_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no special characters",
+			in:   "repository not found",
+			want: "repository not found",
+		},
+		{
+			name: "percent is escaped",
+			in:   "50% off",
+			want: "50%25 off",
+		},
+		{
+			name: "newline is escaped",
+			in:   "line1\nline2",
+			want: "line1%0Aline2",
+		},
+		{
+			name: "carriage return is escaped",
+			in:   "line1\rline2",
+			want: "line1%0Dline2",
+		},
+		{
+			name: "combined special characters",
+			in:   "50% off\r\nnext line",
+			want: "50%25 off%0D%0Anext line",
+		},
+		{
+			name: "percent is escaped before its replacement is rescanned",
+			in:   "%0A",
+			want: "%250A",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, escapeAnnotation(tt.in))
+		})
+	}
+}

--- a/feature/github-repo-importer/pkg/github/github.go
+++ b/feature/github-repo-importer/pkg/github/github.go
@@ -23,6 +23,10 @@ var (
 	v4client *githubv4.Client
 )
 
+// ErrRepoNotFound is returned when the repository to import does not exist or
+// the authenticated GitHub App has no access to it (HTTP 404).
+var ErrRepoNotFound = errors.New("repository not found")
+
 func InitializeClients() {
 	var err error
 	v3client, v4client, err = CreateGitHubClient()
@@ -66,7 +70,10 @@ func ImportRepo(repoName string) (*Repository, error) {
 	repoNameSplit := strings.Split(repoName, "/")
 	repo, r, err := v3client.Repositories.Get(context.Background(), repoNameSplit[0], repoNameSplit[1])
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch repo: %w (API Response: %s)", err, r.Status)
+		if r != nil && r.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("%w: %q — check the spelling and that the GitHub App is installed and has access to it", ErrRepoNotFound, repoName)
+		}
+		return nil, fmt.Errorf("failed to fetch repo %q: %w", repoName, err)
 	}
 
 	if err := dumpManager.WriteJSONFile("repository.json", repo); err != nil {
@@ -94,10 +101,10 @@ func ImportRepo(repoName string) (*Repository, error) {
 
 	rulesets, r, err := v3client.Repositories.GetAllRulesets(context.Background(), repoNameSplit[0], repoNameSplit[1], false)
 	if err != nil {
-		if r.StatusCode == http.StatusForbidden {
+		if r != nil && r.StatusCode == http.StatusForbidden {
 			fmt.Printf("skipping rulesets due to insufficient permissions: %v\n", err)
 		} else {
-			return nil, fmt.Errorf("failed to get all rulesets: %v", err)
+			return nil, fmt.Errorf("failed to get all rulesets: %w", err)
 		}
 	}
 
@@ -134,9 +141,9 @@ func ImportRepo(repoName string) (*Repository, error) {
 		fmt.Printf("failed to write branch_protection_rules.json: %v\n", err)
 	}
 
-	orgTeams, res, err := v3client.Teams.ListTeams(context.Background(), repoNameSplit[0], &github.ListOptions{PerPage: 100})
+	orgTeams, _, err := v3client.Teams.ListTeams(context.Background(), repoNameSplit[0], &github.ListOptions{PerPage: 100})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get org teams: %w (API Response: %s)", err, res.Status)
+		return nil, fmt.Errorf("failed to get org teams: %w", err)
 	}
 
 	if err := dumpManager.WriteJSONFile("org_teams.json", orgTeams); err != nil {


### PR DESCRIPTION
## Handle import errors better (repo not found)

Fixes G-Research/gr-oss#1167

### Problem

When the importer was asked to import a repository that doesn't exist (or that the GitHub App can't see), it produced a noisy, confusing failure:

- The error was **doubled** — `ImportRepo` wrapped it (`failed to fetch repo: ...`) and the command wrapped it again (`failed to import repo: ...`).
- Cobra then dumped the **full command usage/help text** on top of the real message, burying it.
- The raw 404 carried no actionable hint about *why* it failed.
- In GitHub Actions the failure was just a buried log line with no annotation in the run summary.

There was also a latent **nil-pointer panic**: several API error paths dereferenced the HTTP response (`r.Status` / `r.StatusCode`) without a nil check, so a transport-level error would crash with a stack trace instead of a message.

### Changes

**`pkg/github/github.go`**
- Added an `ErrRepoNotFound` sentinel error.
- `ImportRepo` now detects HTTP 404 (`r != nil && r.StatusCode == http.StatusNotFound`) and returns a single, clear message with guidance: *"repository not found: \"owner/repo\" — check the spelling and that the GitHub App is installed and has access to it"*.
- Added the missing `r != nil` guard on the rulesets `403` path (latent nil-deref) and switched its error to `%w` for consistent wrapping.

**`cmd/import.go`**
- Dropped the redundant `failed to import repo: %w` wrap so the underlying message surfaces once.

**`cmd/root.go`**
- Set `SilenceUsage` + `SilenceErrors` on the root command so runtime errors no longer trigger a usage dump; errors are printed once by `Execute`.
- Under GitHub Actions (`GITHUB_ACTIONS=true`), emit a `::error::` workflow-command annotation so the message shows up in the run summary, with proper escaping (`%`, `\r`, `\n`) per GitHub's spec.

**`cmd/root_test.go`** (new)
- Table test for `escapeAnnotation` covering each escape, a combined case, and that `%` is escaped before replacements are re-scanned.

**`Justfile`**
- Added `set -euo pipefail` to the `import-repo` recipe (a shebang recipe) so a failed import aborts instead of falling through to `cp` a stale/missing YAML.

### Before / After

**Before**
```
Error: failed to import repo: failed to fetch repo: GET https://api.github.com/repos/owner/nope: 404 Not Found []  (API Response: 404 Not Found)
Usage:
  importer import [owner/repo] [flags]

Flags:
  -h, --help   help for import
... (full usage dump)
```

**After**
```
Error: repository not found: "owner/nope" — check the spelling and that the GitHub App is installed and has access to it
```
Plus, in GitHub Actions, a `::error::` annotation on the run summary.
