### PR TITLE
GCSS-14: support non-main default branch on repo creation

### DIFF
--- a/feature/github-repo-provisioning/modules/terraform-github-repository/main.tf
+++ b/feature/github-repo-provisioning/modules/terraform-github-repository/main.tf
@@ -191,8 +191,13 @@ resource "github_branch_default" "default" {
 
   repository = github_repository.repository.name
   branch     = local.default_branch
+  rename     = local.default_branch != "main"
 
   depends_on = [github_branch.branch]
+
+  lifecycle {
+    ignore_changes = [rename]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes G-Research/github-terraformer#14

## Problem

When a new repo is created via the importer with a non-`main` default branch (e.g. `master`, `develop`), the freshly auto-init'd GitHub repo lands with `main` as the default. Subsequent applies don't fix it, because the terraform module didn't issue a rename, so the configured `default_branch` was silently ignored.

## Fix

In the vendored `terraform-github-repository` module, set `rename = true` on `github_branch_default` when `default_branch != "main"`, so the freshly created `main` is renamed to the configured default on first apply.

`ignore_changes` on `rename` is added so subsequent applies don't re-issue the rename — the GitHub provider rejects "renaming a branch to itself", which would fail every apply after the first one and on every existing repo whose default branch is already correct.

## Notes

- Net diff: 5 lines added in `feature/github-repo-provisioning/modules/terraform-github-repository/main.tf`.
- Also removes a now-obsolete `feature/github-repo-provisioning/gcss_config/.gitkeep` placeholder.