### PR TITLE
GCSS-49: Fix compare action so import PRs only contain real changes

### DIFF
--- a/.github/actions/compare/action.yaml
+++ b/.github/actions/compare/action.yaml
@@ -20,16 +20,18 @@ runs:
         SOURCE_DIRECTORY: ${{ inputs.source-directory }}
         TARGET_DIRECTORY: ${{ inputs.target-directory }}
       run: |
+        set -euo pipefail
         dirA="${SOURCE_DIRECTORY}"
         dirB="${TARGET_DIRECTORY}"
         result=$(just compare "$dirA" "$dirB")
+        files_to_delete=$(echo "$result" | jq -r '.identical[]?')
         if [[ -z "$files_to_delete" ]]; then
-          echo "No files to delete."
+          echo "No identical (unchanged) files to remove."
         else
-          read -p "Waiting review #1..."
-          echo "Files to delete: [$files_to_delete]"
+          echo "Removing unchanged configs from $dirA so the PR only shows real changes:"
           while IFS= read -r relpath; do
-            rm $dirA/$relpath
+            [[ -z "$relpath" ]] && continue
+            rm "$dirA/$relpath"
             echo "Removed: $relpath"
           done <<< "$files_to_delete"
         fi

--- a/.github/actions/pr-bot/action.yaml
+++ b/.github/actions/pr-bot/action.yaml
@@ -23,15 +23,23 @@ runs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
     - name: Push changes
+      id: push
       shell: bash
       run: |
         cd feature/github-repo-provisioning/gcss_config
-        git checkout -b ${{ inputs.branch-name }}
         git add .
+        if git diff --cached --quiet; then
+          echo "No changes to commit — skipping PR."
+          echo "changes=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        git checkout -b ${{ inputs.branch-name }}
         git commit -m "${{ inputs.commit-message }}"
         git push origin ${{ inputs.branch-name }}
+        echo "changes=true" >> "$GITHUB_OUTPUT"
 
     - name: Create Pull Request
+      if: steps.push.outputs.changes == 'true'
       shell: bash
       run: gh pr create --title "${{ inputs.pr-title }}" --body "This is an automated PR." --base ${{ github.ref_name }} --head ${{ inputs.branch-name }} --repo ${{ github.repository }}
       env:


### PR DESCRIPTION
## What

Fixes the `compare` composite action so it actually removes unchanged configs,
and guards `pr-bot` so it doesn't open empty/noise PRs.

Closes #49. Prerequisite for #1132 (drift check doesn't detect manually-created repos).

## Why

The `compare` action captured the compare command's JSON output into `$result`
but then tested `$files_to_delete`, which was never assigned — so it always hit
the "No files to delete" branch and removed nothing. Every `import` / `bulk-import`
PR therefore contained *every* repo, defeating the purpose of the compare step.

## Changes

**`.github/actions/compare/action.yaml`**
- Parse the `identical` array from the compare JSON with `jq` and remove those
  files from the source dir.
- Remove the leftover interactive `read -p` that would hang in CI.
- Add `set -euo pipefail` and quote the `rm` path.

**`.github/actions/pr-bot/action.yaml`**
- Skip the commit/push and PR creation when there is nothing to commit (the
  now-reachable "no changes" case), preventing a failed empty commit and avoiding
  noise PRs.

## Behaviour change

Both `import.yaml` and `bulk-import.yaml` use these actions. Previously a no-change
run always opened a redundant PR; now it cleanly opens nothing. A run with real
changes opens a PR containing only the new/changed configs.

## Testing

Verified end-to-end in CI against a Milos test org (`milos-org`):

| Scenario | Result |
|---|---|
| Only managed repo, unchanged | compare removed it → pr-bot skipped → **no PR, no failure** |
| Manually-created unmanaged repo present | compare kept it, dropped the unchanged one → **PR opened containing only the new repo** |

Note: for bulk-import to detect manually-created repos, the managing GitHub App
needs org-wide ("All repositories") access - otherwise new repos aren't visible
to the importer.
