### PR TITLE
Support non-main default branch on repo creation

### DIFF
--- a/feature/github-repo-provisioning/modules/terraform-github-repository/main.tf
+++ b/feature/github-repo-provisioning/modules/terraform-github-repository/main.tf
@@ -192,7 +192,20 @@ resource "github_branch_default" "default" {
   repository = github_repository.repository.name
   branch     = local.default_branch
 
+  # On a freshly created repo, auto_init produces a single "main" branch. Pointing the
+  # default at any other branch (e.g. "master") fails with a 422 because that branch does
+  # not exist yet. Rename the auto-init branch to the desired default in that case. We do
+  # not rename when the target is "main" (already the auto-init branch) or when it is an
+  # explicitly managed branch (github_branch.branch), which is created separately above.
+  rename = local.default_branch != "main" && !contains(keys(local.branches_map), local.default_branch)
+
   depends_on = [github_branch.branch]
+
+  # rename only matters at creation time; ignore it afterwards so existing/imported repos
+  # whose default already matches do not show a perpetual diff.
+  lifecycle {
+    ignore_changes = [rename]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a YAML config for a **new** repository sets `default_branch` to anything other than `main`, Terraform fails at apply (issue #14).

`auto_init` creates the repo with a single `main` branch, then `github_branch_default` tries to point the default at e.g. `master`, which does not exist yet:

```
Error: PATCH /repos/<org>/<repo>: 422 Validation Failed
  Field: default_branch  Code: invalid
  Message: The branch master was not found. Please push that ref first or create it via the Git Data API.
```

The repo is left created but with the wrong default branch.

## Fix

Set `rename = true` on `github_branch_default` so the provider renames the auto-init branch (`main`) to the requested default instead of expecting it to already exist.

Renaming is applied only when needed:

```hcl
rename = local.default_branch != "main" && !contains(keys(local.branches_map), local.default_branch)
```

- target is `main` → no rename (it's already the auto-init branch)
- target is an explicitly managed `github_branch` → no rename (that branch is created separately)
- otherwise (e.g. `master`) → rename the auto-init branch to the target

`rename` is wrapped in `lifecycle { ignore_changes = [rename] }` so existing and imported repos whose default already matches do not show a perpetual diff.

## Testing

Reproduced and verified against a test org via local `terraform apply`:

- **Before:** new repo with `default_branch: master` → repo created, apply errors with the 422 above; repo left with default `main`.
- **After:** same config → apply succeeds, repo default branch is `master`, sole branch renamed from `main` to `master`.

Closes #14