### PR TITLE
Add decommission workflow for repos transferred out of the org

### DIFF
--- a/.github/actions/link-backend/action.yaml
+++ b/.github/actions/link-backend/action.yaml
@@ -1,0 +1,16 @@
+name: "Link Terraform backend file"
+description: "Symlinks the selected backend.tf.<backend> to backend.tf before terraform init"
+inputs:
+  backend:
+    description: "Backend variant to activate (matches backend.tf.<backend>)"
+    required: false
+    default: "hcp"
+runs:
+  using: "composite"
+  steps:
+    - name: Link backend file
+      shell: bash
+      working-directory: feature/github-repo-provisioning
+      env:
+        BACKEND: ${{ inputs.backend }}
+      run: ln -sf "backend.tf.${BACKEND}" backend.tf

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -8,7 +8,9 @@ name: Decommission repository
 #   decommission  After approval, runs `terraform state rm` on that list and verifies
 #                 nothing still references the repo.
 #
-# Remove the repo's repos/<repo>.yaml via the normal config PR as part of the same change.
+# Run this WHILE the repo's repos/<repo>.yaml is still present, then delete the YAML
+# afterward via the normal config PR — with the resources already gone from state, that
+# apply is a no-op. (Deleting the YAML first would instead make apply try to destroy it.)
 # WORKSPACE must be a repository-level Actions variable: the discover job and the
 # concurrency group run outside the environment and can't read environment-scoped vars.
 
@@ -61,7 +63,7 @@ jobs:
           path: config-repo
           persist-credentials: false
 
-      - name: Ensure the repository's config has been removed
+      - name: Ensure the repository is still configured
         env:
           REPO: ${{ inputs.repo }}
         run: |
@@ -76,15 +78,19 @@ jobs:
             echo "::error::checked-out repository has no repos/ directory — this workflow must be called from the config repository."
             exit 1
           fi
-          # Terraform reads both repos/ and importer_tmp_dir/, so check both.
+          # Decommission runs WHILE the config is still present (the YAML is deleted
+          # afterward). Require it — running against an already-deleted config means the
+          # order was wrong. Terraform reads both repos/ and importer_tmp_dir/, so accept
+          # the config in either.
           for f in "config-repo/repos/$REPO.yaml" "config-repo/repos/$REPO.yml" \
                    "config-repo/importer_tmp_dir/$REPO.yaml" "config-repo/importer_tmp_dir/$REPO.yml"; do
             if [ -f "$f" ]; then
-              echo "::error::config repo still contains ${f#config-repo/} — merge the deletion PR before decommissioning."
-              exit 1
+              echo "Found config for '$REPO' at ${f#config-repo/} — proceeding."
+              exit 0
             fi
           done
-          echo "Confirmed '$REPO' has no config under repos/ or importer_tmp_dir/."
+          echo "::error::no config found for '$REPO' under repos/ or importer_tmp_dir/ — run decommission while the config is still present, then delete the YAML."
+          exit 1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -50,6 +50,13 @@ on:
         type: string
         required: true
 
+# Serialize all decommission runs against a workspace so two can't race on the same
+# shared state. Queue rather than cancel — a half-finished state operation must not
+# be interrupted.
+concurrency:
+  group: decommission-${{ vars.WORKSPACE }}
+  cancel-in-progress: false
+
 jobs:
   discover:
     name: Discover state resources
@@ -66,6 +73,26 @@ jobs:
           repository: G-Research/github-terraformer
           ref: ${{ inputs.gcss_ref }}
           persist-credentials: false
+
+      # The repo's config lives in the calling config repository. Refuse to touch state
+      # until its YAML has been removed there: otherwise config and state diverge and the
+      # next apply plans to recreate the (now foreign) repo. Removing the YAML first means
+      # the worst case in the gap before this runs is a failed apply, never a recreate.
+      - name: Checkout config repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          path: config-repo
+          persist-credentials: false
+
+      - name: Ensure the repository's config has been removed
+        env:
+          REPO: ${{ inputs.repo }}
+        run: |
+          if [ -f "config-repo/repos/$REPO.yaml" ] || [ -f "config-repo/repos/$REPO.yml" ]; then
+            echo "::error::config repo still contains repos/$REPO.yaml — merge the deletion PR before decommissioning."
+            exit 1
+          fi
+          echo "Confirmed repos/$REPO.{yaml,yml} is absent from the config repo."
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -171,6 +198,7 @@ jobs:
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
       - name: Lock workspace
+        id: lock
         run: |
           set -euo pipefail
           curl -sf -X POST \
@@ -194,8 +222,10 @@ jobs:
             fi
           done < addresses.txt
 
+      # Unlock only a lock we actually acquired, so a failed Lock step (e.g. someone else
+      # holds it) never makes us release their lock.
       - name: Unlock workspace
-        if: always() && steps.ws.outputs.id != ''
+        if: always() && steps.lock.outcome == 'success'
         run: |
           curl -sf -X POST \
             -H "Authorization: Bearer ${{ secrets.tfc_token }}" \

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -12,10 +12,9 @@ name: Decommission repository
 #                 attribute matches (so hashed ruleset keys are never missed). It
 #                 prints the list and hands it to the next job.
 #   decommission  Gated by the `decommission` environment (required reviewers = the
-#                 approval before any state change). Locks the workspace, runs
-#                 `terraform state rm` on the reviewed list, verifies nothing still
-#                 references the repo, then unlocks. State-only: the GitHub repository
-#                 is left untouched.
+#                 approval before any state change). Runs `terraform state rm` on the
+#                 reviewed list, then verifies nothing still references the repo.
+#                 State-only: the GitHub repository is left untouched.
 #
 # Operational note: remove the repo's repos/<repo>.yaml via the normal config PR as part
 # of the same change so config and state stay consistent (no recreate on the next apply).
@@ -43,21 +42,6 @@ on:
     secrets:
       tfc_token:
         description: "Terraform Cloud API token"
-        required: true
-  workflow_dispatch:
-    inputs:
-      repo:
-        description: "Repository to decommission (matches repos/<repo>.yaml)"
-        type: string
-        required: true
-      gcss_ref:
-        description: "GCSS ref to checkout"
-        type: string
-        required: false
-        default: "main"
-      tfc_org:
-        description: "Terraform Cloud organization"
-        type: string
         required: true
 
 # Serialize all decommission runs against a workspace so two can't race on the same
@@ -219,42 +203,6 @@ jobs:
           ln -sf backend.tf.hcp backend.tf
           terraform init -input=false
 
-      - name: Resolve workspace id
-        id: ws
-        env:
-          TFC_TOKEN: ${{ secrets.tfc_token }}
-        run: |
-          set -euo pipefail
-          id=$(curl -fsS --retry 3 --retry-all-errors \
-            -H "Authorization: Bearer $TFC_TOKEN" \
-            -H "Content-Type: application/vnd.api+json" \
-            "https://app.terraform.io/api/v2/organizations/$TF_CLOUD_ORGANIZATION/workspaces/$TF_WORKSPACE" \
-            | jq -r '.data.id')
-          if [ -z "$id" ] || [ "$id" = "null" ]; then
-            echo "::error::could not resolve workspace id for '$TF_WORKSPACE'."
-            exit 1
-          fi
-          echo "id=$id" >> "$GITHUB_OUTPUT"
-
-      # --retry only (no --retry-all-errors): the lock POST is not idempotent — retrying
-      # a request the server already applied turns into a 409 against our own lock.
-      - name: Lock workspace
-        id: lock
-        env:
-          TFC_TOKEN: ${{ secrets.tfc_token }}
-          WS_ID: ${{ steps.ws.outputs.id }}
-          REPO: ${{ inputs.repo }}
-        run: |
-          set -euo pipefail
-          if ! curl -fsS -X POST --retry 3 \
-            -H "Authorization: Bearer $TFC_TOKEN" \
-            -H "Content-Type: application/vnd.api+json" \
-            -d "$(jq -n --arg reason "decommission $REPO" '{reason: $reason}')" \
-            "https://app.terraform.io/api/v2/workspaces/$WS_ID/actions/lock"; then
-            echo "::error::failed to lock workspace '$TF_WORKSPACE' — it may be held by a run or another user. Check the lock in Terraform Cloud (a timed-out lock request may still have been applied) and re-run."
-            exit 1
-          fi
-
       - name: Remove resources from state
         working-directory: feature/github-repo-provisioning
         env:
@@ -281,10 +229,10 @@ jobs:
             echo "All addresses already absent from state. Nothing to remove."
             exit 0
           fi
-          # -lock=false is required: we already hold the workspace lock via the API
-          # (Lock step), so state rm must not try to acquire its own lock or it
-          # deadlocks against ours. Verified against a Terraform Cloud workspace.
-          terraform state rm -lock=false "${to_remove[@]}"
+          # state rm acquires the workspace lock itself for the duration of the operation
+          # (Terraform Cloud serializes runs on a workspace), so no separate lock step is
+          # needed.
+          terraform state rm "${to_remove[@]}"
 
       # The approved list was computed before the approval wait; anything that appeared
       # since (or a resource type discover missed) would be left behind and break the
@@ -313,20 +261,3 @@ jobs:
             exit 1
           fi
           echo "State no longer references '$REPO'."
-
-      # Unlock only a lock we actually acquired, so a failed Lock step (e.g. someone else
-      # holds it) never makes us release their lock. Retry hard: a workspace left locked
-      # blocks every plan and apply in the org.
-      - name: Unlock workspace
-        if: always() && steps.lock.outcome == 'success'
-        env:
-          TFC_TOKEN: ${{ secrets.tfc_token }}
-          WS_ID: ${{ steps.ws.outputs.id }}
-        run: |
-          if ! curl -fsS -X POST --retry 3 --retry-all-errors \
-            -H "Authorization: Bearer $TFC_TOKEN" \
-            -H "Content-Type: application/vnd.api+json" \
-            "https://app.terraform.io/api/v2/workspaces/$WS_ID/actions/unlock"; then
-            echo "::error::failed to unlock workspace '$TF_WORKSPACE' — it stays locked and blocks all plans/applies. Unlock it manually in Terraform Cloud (workspace → force unlock)."
-            exit 1
-          fi

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -8,9 +8,8 @@ name: Decommission repository
 #   decommission  After approval, runs `terraform state rm` on that list and verifies
 #                 nothing still references the repo.
 #
-# Run this WHILE the repo's repos/<repo>.yaml is still present, then delete the YAML
-# afterward via the normal config PR — with the resources already gone from state, that
-# apply is a no-op. (Deleting the YAML first would instead make apply try to destroy it.)
+# Run this while repos/<repo>.yaml is still present, then delete the YAML afterward via
+# the normal config PR — the resources are already out of state, so that apply is a no-op.
 # WORKSPACE must be a repository-level Actions variable: the discover job and the
 # concurrency group run outside the environment and can't read environment-scoped vars.
 
@@ -72,15 +71,13 @@ jobs:
             echo "::error::'$REPO' is not a valid repository name."
             exit 1
           fi
-          # No repos/ dir means this wasn't called from the config repo — refuse rather
-          # than let the check below pass vacuously.
+          # Guard against running outside the config repo (which has a repos/ dir).
           if [ ! -d config-repo/repos ]; then
             echo "::error::checked-out repository has no repos/ directory — this workflow must be called from the config repository."
             exit 1
           fi
-          # Decommission runs WHILE the config is still present (the YAML is deleted
-          # afterward); an already-deleted config means the order was wrong. Terraform
-          # reads both repos/ and importer_tmp_dir/, so accept the config in either.
+          # Decommission runs while the config is still present (deleted afterward), so
+          # require it. Terraform reads repos/ and importer_tmp_dir/, so accept either.
           if [ -f "config-repo/repos/$REPO.yaml" ] || [ -f "config-repo/repos/$REPO.yml" ] \
              || [ -f "config-repo/importer_tmp_dir/$REPO.yaml" ] || [ -f "config-repo/importer_tmp_dir/$REPO.yml" ]; then
             echo "Config for '$REPO' is present — proceeding."

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -79,18 +79,15 @@ jobs:
             exit 1
           fi
           # Decommission runs WHILE the config is still present (the YAML is deleted
-          # afterward). Require it — running against an already-deleted config means the
-          # order was wrong. Terraform reads both repos/ and importer_tmp_dir/, so accept
-          # the config in either.
-          for f in "config-repo/repos/$REPO.yaml" "config-repo/repos/$REPO.yml" \
-                   "config-repo/importer_tmp_dir/$REPO.yaml" "config-repo/importer_tmp_dir/$REPO.yml"; do
-            if [ -f "$f" ]; then
-              echo "Found config for '$REPO' at ${f#config-repo/} — proceeding."
-              exit 0
-            fi
-          done
-          echo "::error::no config found for '$REPO' under repos/ or importer_tmp_dir/ — run decommission while the config is still present, then delete the YAML."
-          exit 1
+          # afterward); an already-deleted config means the order was wrong. Terraform
+          # reads both repos/ and importer_tmp_dir/, so accept the config in either.
+          if [ -f "config-repo/repos/$REPO.yaml" ] || [ -f "config-repo/repos/$REPO.yml" ] \
+             || [ -f "config-repo/importer_tmp_dir/$REPO.yaml" ] || [ -f "config-repo/importer_tmp_dir/$REPO.yml" ]; then
+            echo "Config for '$REPO' is present — proceeding."
+          else
+            echo "::error::no config found for '$REPO' under repos/ or importer_tmp_dir/ — run decommission while the config is still present, then delete the YAML."
+            exit 1
+          fi
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -1,27 +1,16 @@
 name: Decommission repository
 
-# Forgets a repository that has LEFT the org (transferred out or deleted) from the
-# Terraform state WITHOUT destroying it, so the shared workspace stops trying to manage
-# a repo it no longer owns (issue #15). Deleting the repo's YAML alone is not enough:
-# Terraform would then plan to DESTROY a repo the org no longer owns, breaking plans for
-# every repository.
+# Removes a repository that has left the org (transferred out or deleted) from Terraform
+# state without destroying it. Deleting its YAML alone would make Terraform plan a destroy
+# of a repo the org no longer owns, breaking every repository's plan.
 #
-# Two jobs, matching the approval model:
-#   discover      Reads the workspace state and lists every address the repo owns — the
-#                 repository module plus every root-level resource whose `repository`
-#                 attribute matches (so hashed ruleset keys are never missed). It
-#                 prints the list and hands it to the next job.
-#   decommission  Gated by the `decommission` environment (required reviewers = the
-#                 approval before any state change). Runs `terraform state rm` on the
-#                 reviewed list, then verifies nothing still references the repo.
-#                 State-only: the GitHub repository is left untouched.
+#   discover      Lists every state address the repo owns and hands it to the next job.
+#   decommission  After approval, runs `terraform state rm` on that list and verifies
+#                 nothing still references the repo.
 #
-# Operational note: remove the repo's repos/<repo>.yaml via the normal config PR as part
-# of the same change so config and state stay consistent (no recreate on the next apply).
-#
-# Consumer setup: WORKSPACE must be a REPOSITORY-level Actions variable, not scoped to
-# the `decommission` environment — the discover job and the concurrency group below run
-# outside any environment and cannot see environment-scoped variables.
+# Remove the repo's repos/<repo>.yaml via the normal config PR as part of the same change.
+# WORKSPACE must be a repository-level Actions variable: the discover job and the
+# concurrency group run outside the environment and can't read environment-scoped vars.
 
 on:
   workflow_call:
@@ -44,9 +33,7 @@ on:
         description: "Terraform Cloud API token"
         required: true
 
-# Serialize all decommission runs against a workspace so two can't race on the same
-# shared state. Queue rather than cancel — a half-finished state operation must not
-# be interrupted.
+# Serialize runs per workspace; queue rather than cancel so a state op isn't interrupted.
 concurrency:
   group: decommission-${{ vars.WORKSPACE }}
   cancel-in-progress: false
@@ -68,10 +55,6 @@ jobs:
           ref: ${{ inputs.gcss_ref }}
           persist-credentials: false
 
-      # The repo's config lives in the calling config repository. Refuse to touch state
-      # until its YAML has been removed there: otherwise config and state diverge and the
-      # next apply plans to recreate the (now foreign) repo. Removing the YAML first means
-      # the worst case in the gap before this runs is a failed apply, never a recreate.
       - name: Checkout config repo
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -83,21 +66,17 @@ jobs:
           REPO: ${{ inputs.repo }}
         run: |
           set -euo pipefail
-          # Reject anything that isn't a plain repository name before it reaches
-          # terraform/grep/the TFC API.
           if ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::'$REPO' is not a valid repository name."
             exit 1
           fi
-          # The guard is only meaningful against the config repo. When dispatched from
-          # github-terraformer itself the default checkout is NOT the config repo and the
-          # YAML check would pass vacuously — refuse instead of silently skipping it.
+          # No repos/ dir means this wasn't called from the config repo — refuse rather
+          # than let the check below pass vacuously.
           if [ ! -d config-repo/repos ]; then
-            echo "::error::checked-out repository has no repos/ directory — this workflow must be called from the config repository, not dispatched from github-terraformer."
+            echo "::error::checked-out repository has no repos/ directory — this workflow must be called from the config repository."
             exit 1
           fi
-          # Terraform reads both repos/ and importer_tmp_dir/ (imported-but-not-yet-
-          # promoted configs), so the repo must be absent from both.
+          # Terraform reads both repos/ and importer_tmp_dir/, so check both.
           for f in "config-repo/repos/$REPO.yaml" "config-repo/repos/$REPO.yml" \
                    "config-repo/importer_tmp_dir/$REPO.yaml" "config-repo/importer_tmp_dir/$REPO.yml"; do
             if [ -f "$f" ]; then
@@ -133,14 +112,11 @@ jobs:
           terraform show -json > state.json
 
           {
-            # The repository module instance covers the repo and everything nested in it.
             if terraform state list | grep -qF -- "module.repository[\"$REPO\"]"; then
               echo "module.repository[\"$REPO\"]"
             fi
-            # Any root-level resource is matched by its `repository` attribute, so hashed
-            # ruleset keys (sha256("<repo>/<name>")) are never missed and resource types
-            # added later are picked up without editing this list. `?` + `// []` keep this
-            # working on state with no root resources (or no state at all).
+            # Match root-level resources by their repository attribute so hashed ruleset
+            # keys are never missed; ? // [] tolerates empty or absent state.
             jq -r --arg repo "$REPO" '
               (.values.root_module.resources? // [])[]
               | select(.mode == "managed")
@@ -161,7 +137,7 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # Hand the list to the gated job. base64 keeps a multi-line value in one output.
+          # base64 keeps the multi-line list in a single job output.
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "addresses=$(base64 -w0 addresses.txt)" >> "$GITHUB_OUTPUT"
 
@@ -176,8 +152,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.count != '0'
     runs-on: ubuntu-latest
-    # Required reviewers on this environment are the approval gate: the job — and every
-    # state change it makes — waits until an authorized reviewer clicks Approve.
+    # Approval gate: required reviewers on this environment.
     environment: decommission
     permissions:
       contents: read
@@ -211,9 +186,7 @@ jobs:
           set -euo pipefail
           base64 -d <<< "$ADDRESSES_B64" > addresses.txt
 
-          # Snapshot state once and drop anything already gone, so a re-run or resume is
-          # safe; then remove everything in a single state rm (one state write, no
-          # partial-removal window between per-address invocations).
+          # Skip addresses already gone (safe re-run), then remove all in one state rm.
           terraform state list > current.txt
           to_remove=()
           while IFS= read -r addr; do
@@ -229,14 +202,11 @@ jobs:
             echo "All addresses already absent from state. Nothing to remove."
             exit 0
           fi
-          # state rm acquires the workspace lock itself for the duration of the operation
-          # (Terraform Cloud serializes runs on a workspace), so no separate lock step is
-          # needed.
+          # state rm takes the workspace lock itself; no separate lock step needed.
           terraform state rm "${to_remove[@]}"
 
-      # The approved list was computed before the approval wait; anything that appeared
-      # since (or a resource type discover missed) would be left behind and break the
-      # next plan. Fail loudly here instead — a re-run re-discovers and re-approves.
+      # The approved list predates the approval wait; fail if anything still references the
+      # repo so a re-run re-discovers and re-approves it.
       - name: Verify nothing in state still references the repository
         working-directory: feature/github-repo-provisioning
         env:
@@ -256,7 +226,7 @@ jobs:
             ] | .[]
           ' state.json)
           if [ -n "$leftovers" ]; then
-            echo "::error::state still references '$REPO' after removal — re-run the workflow to review and remove the remaining addresses:"
+            echo "::error::state still references '$REPO' after removal — re-run the workflow:"
             echo "$leftovers"
             exit 1
           fi

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -1,0 +1,203 @@
+name: Decommission repository
+
+# Forgets a repository that has LEFT the org (transferred out or deleted) from the
+# Terraform state WITHOUT destroying it, so the shared workspace stops trying to manage
+# a repo it no longer owns (issue #15). Deleting the repo's YAML alone is not enough:
+# Terraform would then plan to DESTROY a repo the org no longer owns, breaking plans for
+# every repository.
+#
+# Two jobs, matching the approval model:
+#   discover      Reads the workspace state and lists every address the repo owns — the
+#                 repository module plus its rulesets/custom properties, matched by their
+#                 `repository` attribute (so hashed ruleset keys are never missed). It
+#                 prints the list and hands it to the next job.
+#   decommission  Gated by the `decommission` environment (required reviewers = the
+#                 approval before any state change). Locks the workspace, runs
+#                 `terraform state rm` on the reviewed list, then unlocks. State-only:
+#                 the GitHub repository is left untouched.
+#
+# Operational note: remove the repo's repos/<repo>.yaml via the normal config PR as part
+# of the same change so config and state stay consistent (no recreate on the next apply).
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "Repository to decommission (matches repos/<repo>.yaml)"
+        type: string
+        required: true
+      gcss_ref:
+        description: "GCSS ref to checkout"
+        type: string
+        required: false
+        default: "main"
+      tfc_org:
+        description: "Terraform Cloud organization"
+        type: string
+        required: true
+    secrets:
+      tfc_token:
+        description: "Terraform Cloud API token"
+        required: true
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Repository to decommission (matches repos/<repo>.yaml)"
+        type: string
+        required: true
+      tfc_org:
+        description: "Terraform Cloud organization"
+        type: string
+        required: true
+
+jobs:
+  discover:
+    name: Discover state resources
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      addresses: ${{ steps.find.outputs.addresses }}
+      count: ${{ steps.find.outputs.count }}
+    steps:
+      - name: Checkout GCSS
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          repository: G-Research/github-terraformer
+          ref: ${{ inputs.gcss_ref }}
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          cli_config_credentials_token: ${{ secrets.tfc_token }}
+
+      - name: Terraform init
+        working-directory: feature/github-repo-provisioning
+        env:
+          TF_CLOUD_ORGANIZATION: ${{ inputs.tfc_org }}
+          TF_WORKSPACE: ${{ vars.WORKSPACE }}
+        run: |
+          ln -sf backend.tf.hcp backend.tf
+          terraform init -input=false
+
+      - name: Find state addresses owned by the repository
+        id: find
+        working-directory: feature/github-repo-provisioning
+        env:
+          TF_CLOUD_ORGANIZATION: ${{ inputs.tfc_org }}
+          TF_WORKSPACE: ${{ vars.WORKSPACE }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          set -euo pipefail
+          terraform show -json > state.json
+
+          {
+            # The repository module instance covers the repo and everything nested in it.
+            if terraform state list | grep -qF -- "module.repository[\"$REPO\"]"; then
+              echo "module.repository[\"$REPO\"]"
+            fi
+            # Root-level rulesets and custom properties are matched by their `repository`
+            # attribute, so hashed ruleset keys (sha256("<repo>/<name>")) are never missed.
+            jq -r --arg repo "$REPO" '
+              .values.root_module.resources[]
+              | select(.type == "github_repository_ruleset" or .type == "github_repository_custom_property")
+              | select(.values.repository == $repo)
+              | .address
+            ' state.json
+          } > addresses.txt
+
+          count=$(grep -c . addresses.txt || true)
+          echo "Found $count address(es) for '$REPO':"
+          cat addresses.txt
+
+          {
+            echo "### Decommission plan for \`$REPO\`"
+            echo "The \`decommission\` job will run \`terraform state rm\` on:"
+            echo '```'
+            cat addresses.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Hand the list to the gated job. base64 keeps a multi-line value in one output.
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "addresses=$(base64 -w0 addresses.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Nothing to decommission
+        if: steps.find.outputs.count == '0'
+        run: echo "::notice::No state resources found for '${{ inputs.repo }}'. Nothing to do."
+
+  decommission:
+    name: Remove resources from state
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    # Required reviewers on this environment are the approval gate: the job — and every
+    # state change it makes — waits until an authorized reviewer clicks Approve.
+    environment: decommission
+    permissions:
+      contents: read
+    env:
+      TF_CLOUD_ORGANIZATION: ${{ inputs.tfc_org }}
+      TF_WORKSPACE: ${{ vars.WORKSPACE }}
+    steps:
+      - name: Checkout GCSS
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          repository: G-Research/github-terraformer
+          ref: ${{ inputs.gcss_ref }}
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          cli_config_credentials_token: ${{ secrets.tfc_token }}
+
+      - name: Terraform init
+        working-directory: feature/github-repo-provisioning
+        run: |
+          ln -sf backend.tf.hcp backend.tf
+          terraform init -input=false
+
+      - name: Resolve workspace id
+        id: ws
+        run: |
+          set -euo pipefail
+          id=$(curl -sf \
+            -H "Authorization: Bearer ${{ secrets.tfc_token }}" \
+            -H "Content-Type: application/vnd.api+json" \
+            "https://app.terraform.io/api/v2/organizations/${{ inputs.tfc_org }}/workspaces/${{ vars.WORKSPACE }}" \
+            | jq -r '.data.id')
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
+      - name: Lock workspace
+        run: |
+          set -euo pipefail
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.tfc_token }}" \
+            -H "Content-Type: application/vnd.api+json" \
+            -d '{"reason":"decommission ${{ inputs.repo }}"}' \
+            "https://app.terraform.io/api/v2/workspaces/${{ steps.ws.outputs.id }}/actions/lock"
+
+      - name: Remove resources from state
+        working-directory: feature/github-repo-provisioning
+        run: |
+          set -euo pipefail
+          base64 -d <<< "${{ needs.discover.outputs.addresses }}" > addresses.txt
+          while IFS= read -r addr; do
+            [ -z "$addr" ] && continue
+            # Idempotent: skip anything already gone, so a re-run or resume is safe.
+            if terraform state list | grep -qF -- "$addr"; then
+              terraform state rm "$addr"
+            else
+              echo "already absent, skipping: $addr"
+            fi
+          done < addresses.txt
+
+      - name: Unlock workspace
+        if: always() && steps.ws.outputs.id != ''
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.tfc_token }}" \
+            -H "Content-Type: application/vnd.api+json" \
+            "https://app.terraform.io/api/v2/workspaces/${{ steps.ws.outputs.id }}/actions/unlock"

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -8,16 +8,21 @@ name: Decommission repository
 #
 # Two jobs, matching the approval model:
 #   discover      Reads the workspace state and lists every address the repo owns — the
-#                 repository module plus its rulesets/custom properties, matched by their
-#                 `repository` attribute (so hashed ruleset keys are never missed). It
+#                 repository module plus every root-level resource whose `repository`
+#                 attribute matches (so hashed ruleset keys are never missed). It
 #                 prints the list and hands it to the next job.
 #   decommission  Gated by the `decommission` environment (required reviewers = the
 #                 approval before any state change). Locks the workspace, runs
-#                 `terraform state rm` on the reviewed list, then unlocks. State-only:
-#                 the GitHub repository is left untouched.
+#                 `terraform state rm` on the reviewed list, verifies nothing still
+#                 references the repo, then unlocks. State-only: the GitHub repository
+#                 is left untouched.
 #
 # Operational note: remove the repo's repos/<repo>.yaml via the normal config PR as part
 # of the same change so config and state stay consistent (no recreate on the next apply).
+#
+# Consumer setup: WORKSPACE must be a REPOSITORY-level Actions variable, not scoped to
+# the `decommission` environment — the discover job and the concurrency group below run
+# outside any environment and cannot see environment-scoped variables.
 
 on:
   workflow_call:
@@ -45,6 +50,11 @@ on:
         description: "Repository to decommission (matches repos/<repo>.yaml)"
         type: string
         required: true
+      gcss_ref:
+        description: "GCSS ref to checkout"
+        type: string
+        required: false
+        default: "main"
       tfc_org:
         description: "Terraform Cloud organization"
         type: string
@@ -88,11 +98,30 @@ jobs:
         env:
           REPO: ${{ inputs.repo }}
         run: |
-          if [ -f "config-repo/repos/$REPO.yaml" ] || [ -f "config-repo/repos/$REPO.yml" ]; then
-            echo "::error::config repo still contains repos/$REPO.yaml — merge the deletion PR before decommissioning."
+          set -euo pipefail
+          # Reject anything that isn't a plain repository name before it reaches
+          # terraform/grep/the TFC API.
+          if ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::'$REPO' is not a valid repository name."
             exit 1
           fi
-          echo "Confirmed repos/$REPO.{yaml,yml} is absent from the config repo."
+          # The guard is only meaningful against the config repo. When dispatched from
+          # github-terraformer itself the default checkout is NOT the config repo and the
+          # YAML check would pass vacuously — refuse instead of silently skipping it.
+          if [ ! -d config-repo/repos ]; then
+            echo "::error::checked-out repository has no repos/ directory — this workflow must be called from the config repository, not dispatched from github-terraformer."
+            exit 1
+          fi
+          # Terraform reads both repos/ and importer_tmp_dir/ (imported-but-not-yet-
+          # promoted configs), so the repo must be absent from both.
+          for f in "config-repo/repos/$REPO.yaml" "config-repo/repos/$REPO.yml" \
+                   "config-repo/importer_tmp_dir/$REPO.yaml" "config-repo/importer_tmp_dir/$REPO.yml"; do
+            if [ -f "$f" ]; then
+              echo "::error::config repo still contains ${f#config-repo/} — merge the deletion PR before decommissioning."
+              exit 1
+            fi
+          done
+          echo "Confirmed '$REPO' has no config under repos/ or importer_tmp_dir/."
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -124,11 +153,13 @@ jobs:
             if terraform state list | grep -qF -- "module.repository[\"$REPO\"]"; then
               echo "module.repository[\"$REPO\"]"
             fi
-            # Root-level rulesets and custom properties are matched by their `repository`
-            # attribute, so hashed ruleset keys (sha256("<repo>/<name>")) are never missed.
+            # Any root-level resource is matched by its `repository` attribute, so hashed
+            # ruleset keys (sha256("<repo>/<name>")) are never missed and resource types
+            # added later are picked up without editing this list. `?` + `// []` keep this
+            # working on state with no root resources (or no state at all).
             jq -r --arg repo "$REPO" '
-              .values.root_module.resources[]
-              | select(.type == "github_repository_ruleset" or .type == "github_repository_custom_property")
+              (.values.root_module.resources? // [])[]
+              | select(.mode == "managed")
               | select(.values.repository == $repo)
               | .address
             ' state.json
@@ -152,7 +183,9 @@ jobs:
 
       - name: Nothing to decommission
         if: steps.find.outputs.count == '0'
-        run: echo "::notice::No state resources found for '${{ inputs.repo }}'. Nothing to do."
+        env:
+          REPO: ${{ inputs.repo }}
+        run: echo "::notice::No state resources found for '$REPO'. Nothing to do."
 
   decommission:
     name: Remove resources from state
@@ -188,49 +221,112 @@ jobs:
 
       - name: Resolve workspace id
         id: ws
+        env:
+          TFC_TOKEN: ${{ secrets.tfc_token }}
         run: |
           set -euo pipefail
-          id=$(curl -sf \
-            -H "Authorization: Bearer ${{ secrets.tfc_token }}" \
+          id=$(curl -fsS --retry 3 --retry-all-errors \
+            -H "Authorization: Bearer $TFC_TOKEN" \
             -H "Content-Type: application/vnd.api+json" \
-            "https://app.terraform.io/api/v2/organizations/${{ inputs.tfc_org }}/workspaces/${{ vars.WORKSPACE }}" \
+            "https://app.terraform.io/api/v2/organizations/$TF_CLOUD_ORGANIZATION/workspaces/$TF_WORKSPACE" \
             | jq -r '.data.id')
+          if [ -z "$id" ] || [ "$id" = "null" ]; then
+            echo "::error::could not resolve workspace id for '$TF_WORKSPACE'."
+            exit 1
+          fi
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
+      # --retry only (no --retry-all-errors): the lock POST is not idempotent — retrying
+      # a request the server already applied turns into a 409 against our own lock.
       - name: Lock workspace
         id: lock
+        env:
+          TFC_TOKEN: ${{ secrets.tfc_token }}
+          WS_ID: ${{ steps.ws.outputs.id }}
+          REPO: ${{ inputs.repo }}
         run: |
           set -euo pipefail
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${{ secrets.tfc_token }}" \
+          if ! curl -fsS -X POST --retry 3 \
+            -H "Authorization: Bearer $TFC_TOKEN" \
             -H "Content-Type: application/vnd.api+json" \
-            -d '{"reason":"decommission ${{ inputs.repo }}"}' \
-            "https://app.terraform.io/api/v2/workspaces/${{ steps.ws.outputs.id }}/actions/lock"
+            -d "$(jq -n --arg reason "decommission $REPO" '{reason: $reason}')" \
+            "https://app.terraform.io/api/v2/workspaces/$WS_ID/actions/lock"; then
+            echo "::error::failed to lock workspace '$TF_WORKSPACE' — it may be held by a run or another user. Check the lock in Terraform Cloud (a timed-out lock request may still have been applied) and re-run."
+            exit 1
+          fi
 
       - name: Remove resources from state
         working-directory: feature/github-repo-provisioning
+        env:
+          ADDRESSES_B64: ${{ needs.discover.outputs.addresses }}
         run: |
           set -euo pipefail
-          base64 -d <<< "${{ needs.discover.outputs.addresses }}" > addresses.txt
+          base64 -d <<< "$ADDRESSES_B64" > addresses.txt
+
+          # Snapshot state once and drop anything already gone, so a re-run or resume is
+          # safe; then remove everything in a single state rm (one state write, no
+          # partial-removal window between per-address invocations).
+          terraform state list > current.txt
+          to_remove=()
           while IFS= read -r addr; do
             [ -z "$addr" ] && continue
-            # Idempotent: skip anything already gone, so a re-run or resume is safe.
-            if terraform state list | grep -qF -- "$addr"; then
-              # -lock=false is required: we already hold the workspace lock via the API
-              # (Lock step), so state rm must not try to acquire its own lock or it
-              # deadlocks against ours. Verified against a Terraform Cloud workspace.
-              terraform state rm -lock=false "$addr"
+            if grep -qF -- "$addr" current.txt; then
+              to_remove+=("$addr")
             else
               echo "already absent, skipping: $addr"
             fi
           done < addresses.txt
 
+          if [ "${#to_remove[@]}" -eq 0 ]; then
+            echo "All addresses already absent from state. Nothing to remove."
+            exit 0
+          fi
+          # -lock=false is required: we already hold the workspace lock via the API
+          # (Lock step), so state rm must not try to acquire its own lock or it
+          # deadlocks against ours. Verified against a Terraform Cloud workspace.
+          terraform state rm -lock=false "${to_remove[@]}"
+
+      # The approved list was computed before the approval wait; anything that appeared
+      # since (or a resource type discover missed) would be left behind and break the
+      # next plan. Fail loudly here instead — a re-run re-discovers and re-approves.
+      - name: Verify nothing in state still references the repository
+        working-directory: feature/github-repo-provisioning
+        env:
+          REPO: ${{ inputs.repo }}
+        run: |
+          set -euo pipefail
+          terraform show -json > state.json
+          leftovers=$(jq -r --arg repo "$REPO" '
+            [
+              ((.values.root_module.resources? // [])[]
+                | select(.mode == "managed")
+                | select(.values.repository == $repo)
+                | .address),
+              ((.values.root_module.child_modules? // [])[]
+                | select(.address == "module.repository[\"" + $repo + "\"]")
+                | .address)
+            ] | .[]
+          ' state.json)
+          if [ -n "$leftovers" ]; then
+            echo "::error::state still references '$REPO' after removal — re-run the workflow to review and remove the remaining addresses:"
+            echo "$leftovers"
+            exit 1
+          fi
+          echo "State no longer references '$REPO'."
+
       # Unlock only a lock we actually acquired, so a failed Lock step (e.g. someone else
-      # holds it) never makes us release their lock.
+      # holds it) never makes us release their lock. Retry hard: a workspace left locked
+      # blocks every plan and apply in the org.
       - name: Unlock workspace
         if: always() && steps.lock.outcome == 'success'
+        env:
+          TFC_TOKEN: ${{ secrets.tfc_token }}
+          WS_ID: ${{ steps.ws.outputs.id }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${{ secrets.tfc_token }}" \
+          if ! curl -fsS -X POST --retry 3 --retry-all-errors \
+            -H "Authorization: Bearer $TFC_TOKEN" \
             -H "Content-Type: application/vnd.api+json" \
-            "https://app.terraform.io/api/v2/workspaces/${{ steps.ws.outputs.id }}/actions/unlock"
+            "https://app.terraform.io/api/v2/workspaces/$WS_ID/actions/unlock"; then
+            echo "::error::failed to unlock workspace '$TF_WORKSPACE' — it stays locked and blocks all plans/applies. Unlock it manually in Terraform Cloud (workspace → force unlock)."
+            exit 1
+          fi

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -91,14 +91,15 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.tfc_token }}
 
+      - name: Link backend file
+        uses: ./.github/actions/link-backend
+
       - name: Terraform init
         working-directory: feature/github-repo-provisioning
         env:
           TF_CLOUD_ORGANIZATION: ${{ inputs.tfc_org }}
           TF_WORKSPACE: ${{ vars.WORKSPACE }}
-        run: |
-          ln -sf backend.tf.hcp backend.tf
-          terraform init -input=false
+        run: terraform init -input=false
 
       - name: Find state addresses owned by the repository
         id: find
@@ -172,11 +173,12 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.tfc_token }}
 
+      - name: Link backend file
+        uses: ./.github/actions/link-backend
+
       - name: Terraform init
         working-directory: feature/github-repo-provisioning
-        run: |
-          ln -sf backend.tf.hcp backend.tf
-          terraform init -input=false
+        run: terraform init -input=false
 
       - name: Remove resources from state
         working-directory: feature/github-repo-provisioning

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -216,7 +216,10 @@ jobs:
             [ -z "$addr" ] && continue
             # Idempotent: skip anything already gone, so a re-run or resume is safe.
             if terraform state list | grep -qF -- "$addr"; then
-              terraform state rm "$addr"
+              # -lock=false is required: we already hold the workspace lock via the API
+              # (Lock step), so state rm must not try to acquire its own lock or it
+              # deadlocks against ours. Verified against a Terraform Cloud workspace.
+              terraform state rm -lock=false "$addr"
             else
               echo "already absent, skipping: $addr"
             fi


### PR DESCRIPTION
## What

Adds a `Decommission repository` workflow that forgets a repo which has **left the org** (transferred out or deleted) from Terraform state **without destroying it**. Resolves #15.

## Why

When a repo is transferred out but its `repos/<repo>.yaml` stays, Terraform still tracks it in the shared workspace. The next run can't read it and fails — and because state is shared, **one orphaned repo blocks PRs for every repository**. Deleting the YAML alone makes Terraform plan a **destroy** of a repo the org no longer owns. The correct action is to remove the resources from **state** (forget), not destroy them.

## How

Two jobs:

- **`discover`** — checks out the config repo and **fails fast if `repos/<repo>.yaml` still exists** (so state is never touched while config still references the repo). Then reads the workspace state and lists every address the repo owns — `module.repository["<repo>"]` plus its rulesets/custom properties, matched by their `repository` attribute in state, so a **hashed `github_repository_ruleset` key is never missed**. Prints the list and hands it to the next job.
- **`decommission`** — gated by the `decommission` environment's **required reviewers** (approval before any state change). Locks the workspace, runs `terraform state rm` on the reviewed list, then unlocks.

## Safety

- **Config guard** — `discover` refuses to run while the YAML still exists (prevents a recreate).
- **Concurrency** — per-workspace group (`cancel-in-progress: false`) so two runs can't race on shared state.
- **Safe unlock** — only releases a lock the run actually acquired.
- **`-lock=false` on `state rm`** — required, because the run already holds the workspace lock via the API; without it `state rm` deadlocks trying to acquire its own lock.
- State-only throughout: the GitHub repository is never touched.

## Operating order

1. Merge the config PR removing `repos/<repo>.yaml`.
2. Run this workflow → approve → state cleaned.

Removing the YAML first means the worst case in the gap is a *failed apply*, never a recreate.

## Consumer setup

Create a **`decommission` environment** with **required reviewers** (the approval gate) + `WORKSPACE` (var) + `tfc_token` (secret). Dispatch it for a repo, or call the reusable workflow from the config repo (like Import).

## Validated end-to-end (GitHub Actions + Terraform Cloud)

Run in the **real Actions runtime against a real TFC workspace** (isolated scratch workspace + throwaway repo — prod state never touched):

- `discover` — config-repo checkout + **YAML fail-fast** passed; `terraform show -json | jq` enumeration found the `module.repository[...]` address and the **ruleset by its real hashed key**, and handed the list to the next job.
- **Approval gate** — the run **paused at `waiting`** on the `decommission` environment and only proceeded after a reviewer approved.
- `decommission` — **lock → `state rm -lock=false` → unlock** removed the module (2 nested instances) + the ruleset.
- Outcome — workspace state **empty** afterwards, while the **repo + ruleset still existed on GitHub** (forget-not-destroy).

Additional checks along the way: the enumeration/`state rm` logic was first verified against the real provisioning module (milos-org), and a TFC dry-run caught that `state rm` **deadlocks** under an API lock unless `-lock=false` is passed (now fixed and re-verified).