### PR TITLE
GCSS-1139: organisation team management via organisation/teams.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Check generated schema is up to date
+      - name: Check generated schemas are up to date
         run: |
           go run . schema
-          git diff --exit-code ../../.schemas/repository-config.schema.json \
-            || { echo "::error::.schemas/repository-config.schema.json is stale. Run 'go run . schema' in feature/github-repo-importer and commit the result."; exit 1; }
+          git diff --exit-code ../../.schemas/repository-config.schema.json ../../.schemas/teams-config.schema.json \
+            || { echo "::error::Generated schemas in .schemas/ are stale. Run 'go run . schema' in feature/github-repo-importer and commit the result."; exit 1; }

--- a/.schemas/teams-config.schema.json
+++ b/.schemas/teams-config.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/.schemas/teams-config.schema.json",
+  "$ref": "#/$defs/TeamsConfig",
+  "$defs": {
+    "Team": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "visible",
+            "secret"
+          ]
+        },
+        "notifications": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "TeamsConfig": {
+      "properties": {
+        "teams": {
+          "items": {
+            "$ref": "#/$defs/Team"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "title": "Teams Configuration"
+}

--- a/.schemas/teams-config.schema.json
+++ b/.schemas/teams-config.schema.json
@@ -11,9 +11,6 @@
         "description": {
           "type": "string"
         },
-        "parent": {
-          "type": "string"
-        },
         "visibility": {
           "type": "string",
           "enum": [

--- a/feature/github-repo-importer/cmd/schema.go
+++ b/feature/github-repo-importer/cmd/schema.go
@@ -14,9 +14,11 @@ import (
 )
 
 const (
-	schemaOutDir       = ".schemas"
-	schemaOutFile      = "repository-config.schema.json"
-	teamsSchemaOutFile = "teams-config.schema.json"
+	schemaOutDir            = ".schemas"
+	repositorySchemaOutFile = "repository-config.schema.json"
+	teamsSchemaOutFile      = "teams-config.schema.json"
+
+	schemaIDURLFormat = "https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/%s/%s"
 )
 
 var schemaCmd = &cobra.Command{
@@ -32,7 +34,7 @@ var schemaCmd = &cobra.Command{
 			outFile string
 			marshal func() ([]byte, error)
 		}{
-			{schemaOutFile, MarshalRepositoryConfigSchema},
+			{repositorySchemaOutFile, MarshalRepositoryConfigSchema},
 			{teamsSchemaOutFile, MarshalTeamsConfigSchema},
 		}
 
@@ -70,7 +72,7 @@ func BuildRepositoryConfigSchema() *jsonschema.Schema {
 
 		schema := reflector.Reflect(&RepositoryWithExpansionConfig{})
 		schema.Title = "Repository Configuration"
-		schema.ID = jsonschema.ID(fmt.Sprintf("https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/%s/%s", schemaOutDir, schemaOutFile))
+		schema.ID = jsonschema.ID(fmt.Sprintf(schemaIDURLFormat, schemaOutDir, repositorySchemaOutFile))
 
 		squashIf := &jsonschema.Schema{
 			Properties: orderedmap.New[string, *jsonschema.Schema](),
@@ -162,7 +164,7 @@ func BuildTeamsConfigSchema() *jsonschema.Schema {
 
 	schema := reflector.Reflect(&github.TeamsConfig{})
 	schema.Title = "Teams Configuration"
-	schema.ID = jsonschema.ID(fmt.Sprintf("https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/%s/%s", schemaOutDir, teamsSchemaOutFile))
+	schema.ID = jsonschema.ID(fmt.Sprintf(schemaIDURLFormat, schemaOutDir, teamsSchemaOutFile))
 
 	return schema
 }

--- a/feature/github-repo-importer/cmd/schema.go
+++ b/feature/github-repo-importer/cmd/schema.go
@@ -53,7 +53,6 @@ var schemaCmd = &cobra.Command{
 	},
 }
 
-// MarshalRepositoryConfigSchema returns the JSON-encoded repository config schema.
 func MarshalRepositoryConfigSchema() ([]byte, error) {
 	data, err := json.MarshalIndent(BuildRepositoryConfigSchema(), "", "  ")
 	if err != nil {
@@ -62,10 +61,6 @@ func MarshalRepositoryConfigSchema() ([]byte, error) {
 	return data, nil
 }
 
-// BuildRepositoryConfigSchema reflects the JSON schema for the repository
-// configuration from the Go structs and applies the manual constraints that
-// cannot be expressed through struct tags. It is the single source of truth
-// shared by the `schema` and `validate` commands.
 func BuildRepositoryConfigSchema() *jsonschema.Schema {
 	{
 		reflector := &jsonschema.Reflector{
@@ -151,7 +146,6 @@ func BuildRepositoryConfigSchema() *jsonschema.Schema {
 	}
 }
 
-// MarshalTeamsConfigSchema returns the JSON-encoded teams config schema.
 func MarshalTeamsConfigSchema() ([]byte, error) {
 	data, err := json.MarshalIndent(BuildTeamsConfigSchema(), "", "  ")
 	if err != nil {
@@ -160,10 +154,6 @@ func MarshalTeamsConfigSchema() ([]byte, error) {
 	return data, nil
 }
 
-// BuildTeamsConfigSchema reflects the JSON schema for the organisation teams
-// configuration (organisation/teams.yaml) from the Go structs. Unlike the
-// repository config schema it needs no manual conditional constraints; the
-// cross-record checks live in github.TeamsConfig.Validate instead.
 func BuildTeamsConfigSchema() *jsonschema.Schema {
 	reflector := &jsonschema.Reflector{
 		AllowAdditionalProperties: false,

--- a/feature/github-repo-importer/cmd/schema.go
+++ b/feature/github-repo-importer/cmd/schema.go
@@ -9,33 +9,46 @@ import (
 	"github.com/invopop/jsonschema"
 	"github.com/spf13/cobra"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
+
+	"github.com/gr-oss-devops/github-repo-importer/pkg/github"
 )
 
 const (
-	schemaOutDir  = ".schemas"
-	schemaOutFile = "repository-config.schema.json"
+	schemaOutDir       = ".schemas"
+	schemaOutFile      = "repository-config.schema.json"
+	teamsSchemaOutFile = "teams-config.schema.json"
 )
 
 var schemaCmd = &cobra.Command{
 	Use:   "schema",
-	Short: "Generate JSON Schema for the repository config",
+	Short: "Generate JSON Schema for the repository and teams configs",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		projectRoot := "../../"
 		if err := os.MkdirAll(fmt.Sprintf("%s/%s", projectRoot, schemaOutDir), 0o755); err != nil {
 			return fmt.Errorf("create %s: %w", schemaOutDir, err)
 		}
 
-		outPath := filepath.Join(projectRoot, schemaOutDir, schemaOutFile)
-
-		data, err := MarshalRepositoryConfigSchema()
-		if err != nil {
-			return err
-		}
-		if err := os.WriteFile(outPath, data, 0o644); err != nil {
-			return fmt.Errorf("write schema file: %w", err)
+		schemas := []struct {
+			outFile string
+			marshal func() ([]byte, error)
+		}{
+			{schemaOutFile, MarshalRepositoryConfigSchema},
+			{teamsSchemaOutFile, MarshalTeamsConfigSchema},
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Schema written to %s\n", outPath)
+		for _, s := range schemas {
+			outPath := filepath.Join(projectRoot, schemaOutDir, s.outFile)
+
+			data, err := s.marshal()
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(outPath, data, 0o644); err != nil {
+				return fmt.Errorf("write schema file: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Schema written to %s\n", outPath)
+		}
 		return nil
 	},
 }
@@ -136,6 +149,32 @@ func BuildRepositoryConfigSchema() *jsonschema.Schema {
 
 		return schema
 	}
+}
+
+// MarshalTeamsConfigSchema returns the JSON-encoded teams config schema.
+func MarshalTeamsConfigSchema() ([]byte, error) {
+	data, err := json.MarshalIndent(BuildTeamsConfigSchema(), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+	return data, nil
+}
+
+// BuildTeamsConfigSchema reflects the JSON schema for the organisation teams
+// configuration (organisation/teams.yaml) from the Go structs. Unlike the
+// repository config schema it needs no manual conditional constraints; the
+// cross-record checks live in github.TeamsConfig.Validate instead.
+func BuildTeamsConfigSchema() *jsonschema.Schema {
+	reflector := &jsonschema.Reflector{
+		AllowAdditionalProperties: false,
+		FieldNameTag:              "yaml",
+	}
+
+	schema := reflector.Reflect(&github.TeamsConfig{})
+	schema.Title = "Teams Configuration"
+	schema.ID = jsonschema.ID(fmt.Sprintf("https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/%s/%s", schemaOutDir, teamsSchemaOutFile))
+
+	return schema
 }
 
 func init() {

--- a/feature/github-repo-importer/cmd/schema_test.go
+++ b/feature/github-repo-importer/cmd/schema_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTeamsConfigSchema(t *testing.T) {
+	schema := BuildTeamsConfigSchema()
+
+	assert.Equal(t, "Teams Configuration", schema.Title)
+	assert.True(t, strings.Contains(string(schema.ID), teamsSchemaOutFile), "schema $id should point at %s, got %s", teamsSchemaOutFile, schema.ID)
+
+	teamsDef, ok := schema.Definitions["TeamsConfig"]
+	assert.True(t, ok, "schema should define TeamsConfig")
+	if ok {
+		_, hasTeams := teamsDef.Properties.Get("teams")
+		assert.True(t, hasTeams, "TeamsConfig should have a teams property")
+	}
+
+	teamDef, ok := schema.Definitions["Team"]
+	assert.True(t, ok, "schema should define Team")
+	if ok {
+		assert.Equal(t, []string{"name"}, teamDef.Required)
+
+		visibility, hasVisibility := teamDef.Properties.Get("visibility")
+		assert.True(t, hasVisibility, "Team should have a visibility property")
+		if hasVisibility {
+			assert.Equal(t, []interface{}{"visible", "secret"}, visibility.Enum)
+		}
+	}
+}
+
+func TestBuildRepositoryConfigSchema(t *testing.T) {
+	schema := BuildRepositoryConfigSchema()
+
+	assert.Equal(t, "Repository Configuration", schema.Title)
+	assert.True(t, strings.Contains(string(schema.ID), schemaOutFile), "schema $id should point at %s, got %s", schemaOutFile, schema.ID)
+}

--- a/feature/github-repo-importer/cmd/schema_test.go
+++ b/feature/github-repo-importer/cmd/schema_test.go
@@ -37,5 +37,5 @@ func TestBuildRepositoryConfigSchema(t *testing.T) {
 	schema := BuildRepositoryConfigSchema()
 
 	assert.Equal(t, "Repository Configuration", schema.Title)
-	assert.True(t, strings.Contains(string(schema.ID), schemaOutFile), "schema $id should point at %s, got %s", schemaOutFile, schema.ID)
+	assert.True(t, strings.Contains(string(schema.ID), repositorySchemaOutFile), "schema $id should point at %s, got %s", repositorySchemaOutFile, schema.ID)
 }

--- a/feature/github-repo-importer/pkg/github/constants.go
+++ b/feature/github-repo-importer/pkg/github/constants.go
@@ -22,8 +22,6 @@ const (
 	VisibilityPrivate = "private"
 	VisibilityPublic  = "public"
 
-	// Team visibility (GitHub UI terms; the provider's `privacy` argument
-	// maps visible -> closed, secret -> secret)
 	TeamVisibilityVisible = "visible"
 	TeamVisibilitySecret  = "secret"
 

--- a/feature/github-repo-importer/pkg/github/constants.go
+++ b/feature/github-repo-importer/pkg/github/constants.go
@@ -22,6 +22,11 @@ const (
 	VisibilityPrivate = "private"
 	VisibilityPublic  = "public"
 
+	// Team visibility (GitHub UI terms; the provider's `privacy` argument
+	// maps visible -> closed, secret -> secret)
+	TeamVisibilityVisible = "visible"
+	TeamVisibilitySecret  = "secret"
+
 	// Permission levels
 	PermissionRead     = "read"
 	PermissionWrite    = "write"

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -1,0 +1,55 @@
+package github
+
+import "fmt"
+
+// TeamsConfig models the organisation/teams.yaml file in the config repo.
+type TeamsConfig struct {
+	Teams []Team `yaml:"teams,omitempty"`
+}
+
+type Team struct {
+	Name          string  `yaml:"name" jsonschema:"required"`
+	Description   *string `yaml:"description,omitempty"`
+	Parent        *string `yaml:"parent,omitempty"`
+	Visibility    string  `yaml:"visibility,omitempty" jsonschema:"enum=visible,enum=secret"`
+	Notifications *bool   `yaml:"notifications,omitempty"`
+}
+
+// Validate performs the cross-record checks that cannot be expressed in JSON
+// Schema alone: every `parent` must refer to a team defined in the same file,
+// and `secret` teams cannot take part in a hierarchy in either direction.
+//
+// Unlike Config.Validate, this returns []error rather than a single error:
+// cmd/validate.go's runValidate already collects and reports every violation
+// across repo configs in one run, and teams validation should surface all
+// problems in a file the same way instead of stopping at the first one.
+func (c *TeamsConfig) Validate() []error {
+	var errs []error
+
+	teamsByName := make(map[string]Team, len(c.Teams))
+	for _, team := range c.Teams {
+		teamsByName[team.Name] = team
+	}
+
+	for _, team := range c.Teams {
+		if team.Parent == nil {
+			continue
+		}
+
+		parent, defined := teamsByName[*team.Parent]
+		if !defined {
+			errs = append(errs, fmt.Errorf("team %q references parent %q which is not defined in teams.yaml", team.Name, *team.Parent))
+			continue
+		}
+
+		if parent.Visibility == TeamVisibilitySecret {
+			errs = append(errs, fmt.Errorf("team %q has secret team %q as parent: secret teams cannot be nested", team.Name, *team.Parent))
+		}
+
+		if team.Visibility == TeamVisibilitySecret {
+			errs = append(errs, fmt.Errorf("secret team %q cannot have a parent: secret teams cannot be nested", team.Name))
+		}
+	}
+
+	return errs
+}

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -19,6 +19,9 @@ func (c *TeamsConfig) Validate() []error {
 
 	teamsByName := make(map[string]Team, len(c.Teams))
 	for _, team := range c.Teams {
+		if _, exists := teamsByName[team.Name]; exists {
+			errs = append(errs, fmt.Errorf("team %q is defined more than once in teams.yaml", team.Name))
+		}
 		teamsByName[team.Name] = team
 	}
 

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -9,7 +9,6 @@ type TeamsConfig struct {
 type Team struct {
 	Name          string  `yaml:"name" jsonschema:"required"`
 	Description   *string `yaml:"description,omitempty"`
-	Parent        *string `yaml:"parent,omitempty"`
 	Visibility    string  `yaml:"visibility,omitempty" jsonschema:"enum=visible,enum=secret"`
 	Notifications *bool   `yaml:"notifications,omitempty"`
 }
@@ -17,32 +16,12 @@ type Team struct {
 func (c *TeamsConfig) Validate() []error {
 	var errs []error
 
-	teamsByName := make(map[string]Team, len(c.Teams))
+	seen := make(map[string]struct{}, len(c.Teams))
 	for _, team := range c.Teams {
-		if _, exists := teamsByName[team.Name]; exists {
+		if _, exists := seen[team.Name]; exists {
 			errs = append(errs, fmt.Errorf("team %q is defined more than once in teams.yaml", team.Name))
 		}
-		teamsByName[team.Name] = team
-	}
-
-	for _, team := range c.Teams {
-		if team.Parent == nil {
-			continue
-		}
-
-		parent, defined := teamsByName[*team.Parent]
-		if !defined {
-			errs = append(errs, fmt.Errorf("team %q references parent %q which is not defined in teams.yaml", team.Name, *team.Parent))
-			continue
-		}
-
-		if parent.Visibility == TeamVisibilitySecret {
-			errs = append(errs, fmt.Errorf("team %q has secret team %q as parent: secret teams cannot be nested", team.Name, *team.Parent))
-		}
-
-		if team.Visibility == TeamVisibilitySecret {
-			errs = append(errs, fmt.Errorf("secret team %q cannot have a parent: secret teams cannot be nested", team.Name))
-		}
+		seen[team.Name] = struct{}{}
 	}
 
 	return errs

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -2,7 +2,6 @@ package github
 
 import "fmt"
 
-// TeamsConfig models the organisation/teams.yaml file in the config repo.
 type TeamsConfig struct {
 	Teams []Team `yaml:"teams,omitempty"`
 }
@@ -15,14 +14,6 @@ type Team struct {
 	Notifications *bool   `yaml:"notifications,omitempty"`
 }
 
-// Validate performs the cross-record checks that cannot be expressed in JSON
-// Schema alone: every `parent` must refer to a team defined in the same file,
-// and `secret` teams cannot take part in a hierarchy in either direction.
-//
-// Unlike Config.Validate, this returns []error rather than a single error:
-// cmd/validate.go's runValidate already collects and reports every violation
-// across repo configs in one run, and teams validation should surface all
-// problems in a file the same way instead of stopping at the first one.
 func (c *TeamsConfig) Validate() []error {
 	var errs []error
 

--- a/feature/github-repo-importer/pkg/github/teams_test.go
+++ b/feature/github-repo-importer/pkg/github/teams_test.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestTeamsConfigValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     TeamsConfig
+		wantErrors []string
+	}{
+		{
+			name: "valid config with nesting and a standalone secret team",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "platform", Visibility: TeamVisibilityVisible},
+					{Name: "platform-oncall", Parent: strPtr("platform"), Visibility: TeamVisibilityVisible},
+					{Name: "security-core", Visibility: TeamVisibilitySecret},
+				},
+			},
+			wantErrors: nil,
+		},
+		{
+			name: "parent not defined in teams.yaml",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "platform-oncall", Parent: strPtr("platform")},
+				},
+			},
+			wantErrors: []string{
+				`team "platform-oncall" references parent "platform" which is not defined in teams.yaml`,
+			},
+		},
+		{
+			name: "secret team used as parent",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "security-core", Visibility: TeamVisibilitySecret},
+					{Name: "security-oncall", Parent: strPtr("security-core"), Visibility: TeamVisibilityVisible},
+				},
+			},
+			wantErrors: []string{
+				`team "security-oncall" has secret team "security-core" as parent: secret teams cannot be nested`,
+			},
+		},
+		{
+			name: "secret team with a parent",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "platform", Visibility: TeamVisibilityVisible},
+					{Name: "security-core", Parent: strPtr("platform"), Visibility: TeamVisibilitySecret},
+				},
+			},
+			wantErrors: []string{
+				`secret team "security-core" cannot have a parent: secret teams cannot be nested`,
+			},
+		},
+		{
+			name: "secret team without a parent is allowed",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "security-core", Visibility: TeamVisibilitySecret},
+				},
+			},
+			wantErrors: nil,
+		},
+		{
+			name: "multiple violations are all reported in one call",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "platform", Visibility: TeamVisibilityVisible},
+					{Name: "ghost-child", Parent: strPtr("ghost")},
+					{Name: "security-core", Visibility: TeamVisibilitySecret},
+					{Name: "security-child", Parent: strPtr("security-core"), Visibility: TeamVisibilitySecret},
+				},
+			},
+			wantErrors: []string{
+				`team "ghost-child" references parent "ghost" which is not defined in teams.yaml`,
+				`team "security-child" has secret team "security-core" as parent: secret teams cannot be nested`,
+				`secret team "security-child" cannot have a parent: secret teams cannot be nested`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.config.Validate()
+
+			var got []string
+			for _, err := range errs {
+				got = append(got, err.Error())
+			}
+			assert.Equal(t, tt.wantErrors, got)
+		})
+	}
+}

--- a/feature/github-repo-importer/pkg/github/teams_test.go
+++ b/feature/github-repo-importer/pkg/github/teams_test.go
@@ -72,6 +72,18 @@ func TestTeamsConfigValidate(t *testing.T) {
 			wantErrors: nil,
 		},
 		{
+			name: "duplicate team name rejected",
+			config: TeamsConfig{
+				Teams: []Team{
+					{Name: "platform", Visibility: TeamVisibilityVisible},
+					{Name: "platform", Visibility: TeamVisibilityVisible},
+				},
+			},
+			wantErrors: []string{
+				`team "platform" is defined more than once in teams.yaml`,
+			},
+		},
+		{
 			name: "multiple violations are all reported in one call",
 			config: TeamsConfig{
 				Teams: []Team{

--- a/feature/github-repo-importer/pkg/github/teams_test.go
+++ b/feature/github-repo-importer/pkg/github/teams_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func strPtr(s string) *string {
-	return &s
-}
-
 func TestTeamsConfigValidate(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -17,55 +13,11 @@ func TestTeamsConfigValidate(t *testing.T) {
 		wantErrors []string
 	}{
 		{
-			name: "valid config with nesting and a standalone secret team",
+			name: "valid config with a standalone secret team",
 			config: TeamsConfig{
 				Teams: []Team{
 					{Name: "platform", Visibility: TeamVisibilityVisible},
-					{Name: "platform-oncall", Parent: strPtr("platform"), Visibility: TeamVisibilityVisible},
-					{Name: "security-core", Visibility: TeamVisibilitySecret},
-				},
-			},
-			wantErrors: nil,
-		},
-		{
-			name: "parent not defined in teams.yaml",
-			config: TeamsConfig{
-				Teams: []Team{
-					{Name: "platform-oncall", Parent: strPtr("platform")},
-				},
-			},
-			wantErrors: []string{
-				`team "platform-oncall" references parent "platform" which is not defined in teams.yaml`,
-			},
-		},
-		{
-			name: "secret team used as parent",
-			config: TeamsConfig{
-				Teams: []Team{
-					{Name: "security-core", Visibility: TeamVisibilitySecret},
-					{Name: "security-oncall", Parent: strPtr("security-core"), Visibility: TeamVisibilityVisible},
-				},
-			},
-			wantErrors: []string{
-				`team "security-oncall" has secret team "security-core" as parent: secret teams cannot be nested`,
-			},
-		},
-		{
-			name: "secret team with a parent",
-			config: TeamsConfig{
-				Teams: []Team{
-					{Name: "platform", Visibility: TeamVisibilityVisible},
-					{Name: "security-core", Parent: strPtr("platform"), Visibility: TeamVisibilitySecret},
-				},
-			},
-			wantErrors: []string{
-				`secret team "security-core" cannot have a parent: secret teams cannot be nested`,
-			},
-		},
-		{
-			name: "secret team without a parent is allowed",
-			config: TeamsConfig{
-				Teams: []Team{
+					{Name: "platform-oncall", Visibility: TeamVisibilityVisible},
 					{Name: "security-core", Visibility: TeamVisibilitySecret},
 				},
 			},
@@ -84,19 +36,18 @@ func TestTeamsConfigValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple violations are all reported in one call",
+			name: "multiple duplicates all reported in one call",
 			config: TeamsConfig{
 				Teams: []Team{
 					{Name: "platform", Visibility: TeamVisibilityVisible},
-					{Name: "ghost-child", Parent: strPtr("ghost")},
+					{Name: "platform", Visibility: TeamVisibilityVisible},
 					{Name: "security-core", Visibility: TeamVisibilitySecret},
-					{Name: "security-child", Parent: strPtr("security-core"), Visibility: TeamVisibilitySecret},
+					{Name: "security-core", Visibility: TeamVisibilitySecret},
 				},
 			},
 			wantErrors: []string{
-				`team "ghost-child" references parent "ghost" which is not defined in teams.yaml`,
-				`team "security-child" has secret team "security-core" as parent: secret teams cannot be nested`,
-				`secret team "security-child" cannot have a parent: secret teams cannot be nested`,
+				`team "platform" is defined more than once in teams.yaml`,
+				`team "security-core" is defined more than once in teams.yaml`,
 			},
 		},
 	}

--- a/feature/github-repo-provisioning/backend.tf.hcp
+++ b/feature/github-repo-provisioning/backend.tf.hcp
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     github = {
       source = "G-Research-Forks/github"
-      version = "6.9.0-gr.3"
+      version = "6.11.1-gr.1"
     }
   }
 }

--- a/feature/github-repo-provisioning/backend.tf.local
+++ b/feature/github-repo-provisioning/backend.tf.local
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     github = {
       source = "G-Research-Forks/github"
-      version = "6.9.0-gr.3"
+      version = "6.11.1-gr.1"
     }
   }
 }

--- a/feature/github-repo-provisioning/modules/terraform-github-repository/versions.tf
+++ b/feature/github-repo-provisioning/modules/terraform-github-repository/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     github = {
       source = "G-Research-Forks/github"
-      version = "6.9.0-gr.3"
+      version = "6.11.1-gr.1"
     }
   }
 }

--- a/feature/github-repo-provisioning/teams.tf
+++ b/feature/github-repo-provisioning/teams.tf
@@ -12,6 +12,6 @@ resource "github_team" "team" {
   name                 = each.value.name
   description          = try(each.value.description, null)
   privacy              = try(each.value.visibility, "visible") == "secret" ? "secret" : "closed"
-  notification_setting = try(each.value.notifications, true) ? "notifications_enabled" : "notifications_disabled"
+  notification_setting = coalesce(try(each.value.notifications, true), true) ? "notifications_enabled" : "notifications_disabled"
   parent_team_id       = try(each.value.parent, null) != null ? github_team.team[each.value.parent].id : null
 }

--- a/feature/github-repo-provisioning/teams.tf
+++ b/feature/github-repo-provisioning/teams.tf
@@ -1,0 +1,20 @@
+# Organisation teams, managed from gcss_config/organisation/teams.yaml.
+# The YAML uses GitHub UI terms (visibility: visible | secret) which map to the
+# provider's privacy argument as visible -> closed, secret -> secret.
+locals {
+  teams_config_files = fileset(path.module, "gcss_config/organisation/teams.yaml")
+
+  teams_raw = length(local.teams_config_files) > 0 ? yamldecode(file("${path.module}/gcss_config/organisation/teams.yaml")) : { teams = [] }
+
+  teams_by_name = { for t in try(local.teams_raw.teams, []) : t.name => t }
+}
+
+resource "github_team" "team" {
+  for_each = local.teams_by_name
+
+  name                 = each.value.name
+  description          = try(each.value.description, null)
+  privacy              = try(each.value.visibility, "visible") == "secret" ? "secret" : "closed"
+  notification_setting = try(each.value.notifications, true) ? "notifications_enabled" : "notifications_disabled"
+  parent_team_id       = try(each.value.parent, null) != null ? github_team.team[each.value.parent].id : null
+}

--- a/feature/github-repo-provisioning/teams.tf
+++ b/feature/github-repo-provisioning/teams.tf
@@ -1,6 +1,3 @@
-# Organisation teams, managed from gcss_config/organisation/teams.yaml.
-# The YAML uses GitHub UI terms (visibility: visible | secret) which map to the
-# provider's privacy argument as visible -> closed, secret -> secret.
 locals {
   teams_config_files = fileset(path.module, "gcss_config/organisation/teams.yaml")
 

--- a/feature/github-repo-provisioning/teams.tf
+++ b/feature/github-repo-provisioning/teams.tf
@@ -13,5 +13,4 @@ resource "github_team" "team" {
   description          = try(each.value.description, null)
   privacy              = try(each.value.visibility, "visible") == "secret" ? "secret" : "closed"
   notification_setting = coalesce(try(each.value.notifications, true), true) ? "notifications_enabled" : "notifications_disabled"
-  parent_team_id       = try(each.value.parent, null) != null ? github_team.team[each.value.parent].id : null
 }


### PR DESCRIPTION
Implements GCSS-1139.

## What this does

Brings organisation **teams** under GCSS. Teams are now described in a single `organisation/teams.yaml` file in the config repo and reconciled by Terraform — the same "config as code" model already used for repositories.

Each team supports:

| Field | Notes |
|---|---|
| `name` | required |
| `description` | optional |
| `visibility` | `visible` or `secret` — defaults to `visible` |
| `notifications` | `true` or `false` — defaults to `true` |

The YAML uses the friendly GitHub-UI wording, and GCSS translates it to the provider's arguments under the hood:

- `visibility: visible` → `privacy = closed`, `visibility: secret` → `privacy = secret`
- `notifications: true / false` → `notification_setting = notifications_enabled / notifications_disabled`

Adding or removing a team is just a YAML edit — no Terraform changes needed.

## What's included

- **Provider bump** to `6.11.1-gr.1` — the first fork version that exposes `notification_setting` on `github_team`. Updated in all three places it's pinned.
- **`github_team` resource** — a single `for_each` over the teams, keyed by name.
- **JSON schema + Go model** for `teams.yaml`, generated from the structs and kept honest by a CI check. Unknown fields and invalid `visibility` values are rejected.
- **Validation** (duplicate-name detection), ready to plug into the config validation step.

## A note on nesting

The original design included nested teams via a `parent` field. Terraform can't express that cleanly — a resource that references other instances of itself forms a dependency cycle, which blocks the plan entirely. We tried a few alternatives; each only worked for a single level of nesting or came with awkward trade-offs. So the call was to **ship flat teams now** and revisit nesting separately with a proper design. The `parent` field has been removed from the schema, so it's rejected rather than silently ignored.

## Testing

Verified end-to-end against a testing org:

- Applied a `teams.yaml` with one visible team and one secret team — both created successfully.
- Checked the real settings via the GitHub API: the visible team came out as `privacy = closed` / `notifications_enabled`, and the secret team as `privacy = secret` / `notifications_disabled` — exactly matching the YAML.
- Ran `terraform destroy` — both teams removed cleanly, org back to zero teams.
- Confirmed `terraform init` installs the new provider version, and the Go tests and schema generation all pass.

## Follow-ups (tracked separately)

- Wiring the schema + validation into the pre-plan check, with CODEOWNERS gating.
- A bootstrap importer so the first apply against an existing org is a no-op rather than trying to recreate teams that already exist.
- Members and team membership.
