### PR TITLE
Use link-backend action in graformer

### DIFF
--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -36,17 +36,9 @@ runs:
         cli_config_credentials_token: ${{ inputs.tfc-token }}
 
     - name: Link backend file
-      id: link
-      shell: bash
-      working-directory: feature/github-repo-provisioning
-      env:
-        BACKEND: ${{ env.BACKEND }}
-      run: |
-        if [[ -n "${BACKEND}" ]]; then
-          ln -sf "backend.tf.${BACKEND}" backend.tf
-        else
-          ln -sf backend.tf.hcp backend.tf
-        fi
+      uses: ./.github/actions/link-backend
+      with:
+        backend: ${{ env.BACKEND }}
 
     - name: Terraform fmt
       id: fmt

--- a/.github/actions/link-backend/action.yaml
+++ b/.github/actions/link-backend/action.yaml
@@ -2,7 +2,7 @@ name: "Link Terraform backend file"
 description: "Symlinks the selected backend.tf.<backend> to backend.tf before terraform init"
 inputs:
   backend:
-    description: "Backend variant to activate (matches backend.tf.<backend>)"
+    description: "Backend variant to activate (matches backend.tf.<backend>); empty selects hcp"
     required: false
     default: "hcp"
 runs:
@@ -13,4 +13,4 @@ runs:
       working-directory: feature/github-repo-provisioning
       env:
         BACKEND: ${{ inputs.backend }}
-      run: ln -sf "backend.tf.${BACKEND}" backend.tf
+      run: ln -sf "backend.tf.${BACKEND:-hcp}" backend.tf


### PR DESCRIPTION
Replace graformer's inline backend-link step with the link-backend composite action, so the `ln -sf` logic lives in one place. Add an hcp fallback to link-backend so an empty backend value (BACKEND env var unset) selects hcp.

Ref: G-Research/gr-oss#1396