### PR TITLE
GCSS-1390: organisation members management via organisation/members.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,5 +27,5 @@ jobs:
       - name: Check generated schemas are up to date
         run: |
           go run . schema
-          git diff --exit-code ../../.schemas/repository-config.schema.json ../../.schemas/teams-config.schema.json \
+          git diff --exit-code ../../.schemas/repository-config.schema.json ../../.schemas/teams-config.schema.json ../../.schemas/members-config.schema.json \
             || { echo "::error::Generated schemas in .schemas/ are stale. Run 'go run . schema' in feature/github-repo-importer and commit the result."; exit 1; }

--- a/.schemas/members-config.schema.json
+++ b/.schemas/members-config.schema.json
@@ -17,10 +17,9 @@
         },
         "teams": {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/TeamMembership"
           },
-          "type": "array",
-          "uniqueItems": true
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -40,6 +39,25 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "TeamMembership": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "member",
+            "maintainer"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
     }
   },
   "title": "Members Configuration"

--- a/.schemas/members-config.schema.json
+++ b/.schemas/members-config.schema.json
@@ -19,7 +19,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         }
       },
       "additionalProperties": false,

--- a/.schemas/members-config.schema.json
+++ b/.schemas/members-config.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/.schemas/members-config.schema.json",
+  "$ref": "#/$defs/MembersConfig",
+  "$defs": {
+    "Member": {
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "owner",
+            "member"
+          ]
+        },
+        "teams": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "username"
+      ]
+    },
+    "MembersConfig": {
+      "properties": {
+        "members": {
+          "items": {
+            "$ref": "#/$defs/Member"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "title": "Members Configuration"
+}

--- a/feature/github-repo-importer/cmd/schema.go
+++ b/feature/github-repo-importer/cmd/schema.go
@@ -17,13 +17,14 @@ const (
 	schemaOutDir            = ".schemas"
 	repositorySchemaOutFile = "repository-config.schema.json"
 	teamsSchemaOutFile      = "teams-config.schema.json"
+	membersSchemaOutFile    = "members-config.schema.json"
 
 	schemaIDURLFormat = "https://raw.githubusercontent.com/G-Research/github-terraformer/refs/heads/main/%s/%s"
 )
 
 var schemaCmd = &cobra.Command{
 	Use:   "schema",
-	Short: "Generate JSON Schema for the repository and teams configs",
+	Short: "Generate JSON Schema for the repository, teams, and members configs",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		projectRoot := "../../"
 		if err := os.MkdirAll(fmt.Sprintf("%s/%s", projectRoot, schemaOutDir), 0o755); err != nil {
@@ -36,6 +37,7 @@ var schemaCmd = &cobra.Command{
 		}{
 			{repositorySchemaOutFile, MarshalRepositoryConfigSchema},
 			{teamsSchemaOutFile, MarshalTeamsConfigSchema},
+			{membersSchemaOutFile, MarshalMembersConfigSchema},
 		}
 
 		for _, s := range schemas {
@@ -165,6 +167,27 @@ func BuildTeamsConfigSchema() *jsonschema.Schema {
 	schema := reflector.Reflect(&github.TeamsConfig{})
 	schema.Title = "Teams Configuration"
 	schema.ID = jsonschema.ID(fmt.Sprintf(schemaIDURLFormat, schemaOutDir, teamsSchemaOutFile))
+
+	return schema
+}
+
+func MarshalMembersConfigSchema() ([]byte, error) {
+	data, err := json.MarshalIndent(BuildMembersConfigSchema(), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+	return data, nil
+}
+
+func BuildMembersConfigSchema() *jsonschema.Schema {
+	reflector := &jsonschema.Reflector{
+		AllowAdditionalProperties: false,
+		FieldNameTag:              "yaml",
+	}
+
+	schema := reflector.Reflect(&github.MembersConfig{})
+	schema.Title = "Members Configuration"
+	schema.ID = jsonschema.ID(fmt.Sprintf(schemaIDURLFormat, schemaOutDir, membersSchemaOutFile))
 
 	return schema
 }

--- a/feature/github-repo-importer/cmd/schema_test.go
+++ b/feature/github-repo-importer/cmd/schema_test.go
@@ -57,10 +57,19 @@ func TestBuildMembersConfigSchema(t *testing.T) {
 			assert.Equal(t, []interface{}{"owner", "member"}, role.Enum)
 		}
 
-		teams, hasTeams := memberDef.Properties.Get("teams")
+		_, hasTeams := memberDef.Properties.Get("teams")
 		assert.True(t, hasTeams, "Member should have a teams property")
-		if hasTeams {
-			assert.True(t, teams.UniqueItems, "teams should require unique items")
+	}
+
+	teamMembershipDef, ok := schema.Definitions["TeamMembership"]
+	assert.True(t, ok, "schema should define TeamMembership")
+	if ok {
+		assert.Equal(t, []string{"name"}, teamMembershipDef.Required)
+
+		role, hasRole := teamMembershipDef.Properties.Get("role")
+		assert.True(t, hasRole, "TeamMembership should have a role property")
+		if hasRole {
+			assert.Equal(t, []interface{}{"member", "maintainer"}, role.Enum)
 		}
 	}
 }

--- a/feature/github-repo-importer/cmd/schema_test.go
+++ b/feature/github-repo-importer/cmd/schema_test.go
@@ -56,6 +56,12 @@ func TestBuildMembersConfigSchema(t *testing.T) {
 		if hasRole {
 			assert.Equal(t, []interface{}{"owner", "member"}, role.Enum)
 		}
+
+		teams, hasTeams := memberDef.Properties.Get("teams")
+		assert.True(t, hasTeams, "Member should have a teams property")
+		if hasTeams {
+			assert.True(t, teams.UniqueItems, "teams should require unique items")
+		}
 	}
 }
 

--- a/feature/github-repo-importer/cmd/schema_test.go
+++ b/feature/github-repo-importer/cmd/schema_test.go
@@ -33,6 +33,32 @@ func TestBuildTeamsConfigSchema(t *testing.T) {
 	}
 }
 
+func TestBuildMembersConfigSchema(t *testing.T) {
+	schema := BuildMembersConfigSchema()
+
+	assert.Equal(t, "Members Configuration", schema.Title)
+	assert.True(t, strings.Contains(string(schema.ID), membersSchemaOutFile), "schema $id should point at %s, got %s", membersSchemaOutFile, schema.ID)
+
+	membersDef, ok := schema.Definitions["MembersConfig"]
+	assert.True(t, ok, "schema should define MembersConfig")
+	if ok {
+		_, hasMembers := membersDef.Properties.Get("members")
+		assert.True(t, hasMembers, "MembersConfig should have a members property")
+	}
+
+	memberDef, ok := schema.Definitions["Member"]
+	assert.True(t, ok, "schema should define Member")
+	if ok {
+		assert.Equal(t, []string{"username"}, memberDef.Required)
+
+		role, hasRole := memberDef.Properties.Get("role")
+		assert.True(t, hasRole, "Member should have a role property")
+		if hasRole {
+			assert.Equal(t, []interface{}{"owner", "member"}, role.Enum)
+		}
+	}
+}
+
 func TestBuildRepositoryConfigSchema(t *testing.T) {
 	schema := BuildRepositoryConfigSchema()
 

--- a/feature/github-repo-importer/pkg/github/constants.go
+++ b/feature/github-repo-importer/pkg/github/constants.go
@@ -25,6 +25,9 @@ const (
 	TeamVisibilityVisible = "visible"
 	TeamVisibilitySecret  = "secret"
 
+	MemberRoleOwner  = "owner"
+	MemberRoleMember = "member"
+
 	// Permission levels
 	PermissionRead     = "read"
 	PermissionWrite    = "write"

--- a/feature/github-repo-importer/pkg/github/constants.go
+++ b/feature/github-repo-importer/pkg/github/constants.go
@@ -28,6 +28,9 @@ const (
 	MemberRoleOwner  = "owner"
 	MemberRoleMember = "member"
 
+	TeamRoleMember     = "member"
+	TeamRoleMaintainer = "maintainer"
+
 	// Permission levels
 	PermissionRead     = "read"
 	PermissionWrite    = "write"

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -7,9 +7,14 @@ type MembersConfig struct {
 }
 
 type Member struct {
-	Username string   `yaml:"username" jsonschema:"required"`
-	Role     string   `yaml:"role,omitempty" jsonschema:"enum=owner,enum=member"`
-	Teams    []string `yaml:"teams,omitempty" jsonschema:"uniqueItems=true"`
+	Username string           `yaml:"username" jsonschema:"required"`
+	Role     string           `yaml:"role,omitempty" jsonschema:"enum=owner,enum=member"`
+	Teams    []TeamMembership `yaml:"teams,omitempty"`
+}
+
+type TeamMembership struct {
+	Name string `yaml:"name" jsonschema:"required"`
+	Role string `yaml:"role,omitempty" jsonschema:"enum=member,enum=maintainer"`
 }
 
 func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) []error {
@@ -29,13 +34,13 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 
 		memberTeams := make(map[string]struct{}, len(member.Teams))
 		for _, team := range member.Teams {
-			if _, exists := memberTeams[team]; exists {
-				errs = append(errs, fmt.Errorf("member %q lists team %q more than once", member.Username, team))
+			if _, exists := memberTeams[team.Name]; exists {
+				errs = append(errs, fmt.Errorf("member %q lists team %q more than once", member.Username, team.Name))
 			}
-			memberTeams[team] = struct{}{}
+			memberTeams[team.Name] = struct{}{}
 
-			if _, ok := teamSet[team]; !ok {
-				errs = append(errs, fmt.Errorf("member %q references team %q which is not defined in teams.yaml", member.Username, team))
+			if _, ok := teamSet[team.Name]; !ok {
+				errs = append(errs, fmt.Errorf("member %q references team %q which is not defined in teams.yaml", member.Username, team.Name))
 			}
 		}
 	}

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -9,7 +9,7 @@ type MembersConfig struct {
 type Member struct {
 	Username string   `yaml:"username" jsonschema:"required"`
 	Role     string   `yaml:"role,omitempty" jsonschema:"enum=owner,enum=member"`
-	Teams    []string `yaml:"teams,omitempty"`
+	Teams    []string `yaml:"teams,omitempty" jsonschema:"uniqueItems=true"`
 }
 
 func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) []error {
@@ -27,7 +27,13 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 		}
 		seen[member.Username] = member
 
+		memberTeams := make(map[string]struct{}, len(member.Teams))
 		for _, team := range member.Teams {
+			if _, exists := memberTeams[team]; exists {
+				errs = append(errs, fmt.Errorf("member %q lists team %q more than once", member.Username, team))
+			}
+			memberTeams[team] = struct{}{}
+
 			if _, ok := teamSet[team]; !ok {
 				errs = append(errs, fmt.Errorf("member %q references team %q which is not defined in teams.yaml", member.Username, team))
 			}

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -1,0 +1,49 @@
+package github
+
+import "fmt"
+
+type MembersConfig struct {
+	Members []Member `yaml:"members,omitempty"`
+}
+
+type Member struct {
+	Username string   `yaml:"username" jsonschema:"required"`
+	Role     string   `yaml:"role,omitempty" jsonschema:"enum=owner,enum=member"`
+	Teams    []string `yaml:"teams,omitempty"`
+}
+
+func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) []error {
+	var errs []error
+
+	teamSet := make(map[string]struct{}, len(knownTeams))
+	for _, t := range knownTeams {
+		teamSet[t] = struct{}{}
+	}
+
+	seen := make(map[string]Member, len(c.Members))
+	for _, member := range c.Members {
+		if _, exists := seen[member.Username]; exists {
+			errs = append(errs, fmt.Errorf("member %q is defined more than once in members.yaml", member.Username))
+		}
+		seen[member.Username] = member
+
+		for _, team := range member.Teams {
+			if _, ok := teamSet[team]; !ok {
+				errs = append(errs, fmt.Errorf("member %q references team %q which is not defined in teams.yaml", member.Username, team))
+			}
+		}
+	}
+
+	for _, owner := range protectedOwners {
+		member, present := seen[owner]
+		if !present {
+			errs = append(errs, fmt.Errorf("protected owner %q is missing from members.yaml: protected identities cannot be removed", owner))
+			continue
+		}
+		if member.Role != MemberRoleOwner {
+			errs = append(errs, fmt.Errorf("protected owner %q has role %q: protected identities cannot be demoted from owner", owner, member.Role))
+		}
+	}
+
+	return errs
+}

--- a/feature/github-repo-importer/pkg/github/members_test.go
+++ b/feature/github-repo-importer/pkg/github/members_test.go
@@ -51,6 +51,17 @@ func TestMembersConfigValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "duplicate team within a member's teams list rejected",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleMember, Teams: []string{"platform", "platform"}},
+				},
+			},
+			wantErrors: []string{
+				`member "alice" lists team "platform" more than once`,
+			},
+		},
+		{
 			name: "protected owner missing from members.yaml",
 			config: MembersConfig{
 				Members: []Member{

--- a/feature/github-repo-importer/pkg/github/members_test.go
+++ b/feature/github-repo-importer/pkg/github/members_test.go
@@ -16,11 +16,11 @@ func TestMembersConfigValidate(t *testing.T) {
 		wantErrors      []string
 	}{
 		{
-			name: "valid config",
+			name: "valid config with team member and maintainer roles",
 			config: MembersConfig{
 				Members: []Member{
-					{Username: "alice", Role: MemberRoleOwner, Teams: []string{"platform"}},
-					{Username: "bob", Role: MemberRoleMember, Teams: []string{"platform", "security-core"}},
+					{Username: "alice", Role: MemberRoleOwner, Teams: []TeamMembership{{Name: "platform"}}},
+					{Username: "bob", Role: MemberRoleMember, Teams: []TeamMembership{{Name: "platform", Role: TeamRoleMaintainer}, {Name: "security-core"}}},
 					{Username: "carol", Role: MemberRoleMember},
 				},
 			},
@@ -43,7 +43,7 @@ func TestMembersConfigValidate(t *testing.T) {
 			name: "team reference not defined in teams.yaml",
 			config: MembersConfig{
 				Members: []Member{
-					{Username: "alice", Role: MemberRoleMember, Teams: []string{"ghost"}},
+					{Username: "alice", Role: MemberRoleMember, Teams: []TeamMembership{{Name: "ghost"}}},
 				},
 			},
 			wantErrors: []string{
@@ -54,7 +54,7 @@ func TestMembersConfigValidate(t *testing.T) {
 			name: "duplicate team within a member's teams list rejected",
 			config: MembersConfig{
 				Members: []Member{
-					{Username: "alice", Role: MemberRoleMember, Teams: []string{"platform", "platform"}},
+					{Username: "alice", Role: MemberRoleMember, Teams: []TeamMembership{{Name: "platform"}, {Name: "platform", Role: TeamRoleMaintainer}}},
 				},
 			},
 			wantErrors: []string{
@@ -89,7 +89,7 @@ func TestMembersConfigValidate(t *testing.T) {
 			name: "multiple violations all reported in one call",
 			config: MembersConfig{
 				Members: []Member{
-					{Username: "alice", Role: MemberRoleMember, Teams: []string{"ghost"}},
+					{Username: "alice", Role: MemberRoleMember, Teams: []TeamMembership{{Name: "ghost"}}},
 					{Username: "alice", Role: MemberRoleMember},
 				},
 			},

--- a/feature/github-repo-importer/pkg/github/members_test.go
+++ b/feature/github-repo-importer/pkg/github/members_test.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMembersConfigValidate(t *testing.T) {
+	knownTeams := []string{"platform", "security-core"}
+
+	tests := []struct {
+		name            string
+		config          MembersConfig
+		protectedOwners []string
+		wantErrors      []string
+	}{
+		{
+			name: "valid config",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleOwner, Teams: []string{"platform"}},
+					{Username: "bob", Role: MemberRoleMember, Teams: []string{"platform", "security-core"}},
+					{Username: "carol", Role: MemberRoleMember},
+				},
+			},
+			protectedOwners: []string{"alice"},
+			wantErrors:      nil,
+		},
+		{
+			name: "duplicate username rejected",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleMember},
+					{Username: "alice", Role: MemberRoleMember},
+				},
+			},
+			wantErrors: []string{
+				`member "alice" is defined more than once in members.yaml`,
+			},
+		},
+		{
+			name: "team reference not defined in teams.yaml",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleMember, Teams: []string{"ghost"}},
+				},
+			},
+			wantErrors: []string{
+				`member "alice" references team "ghost" which is not defined in teams.yaml`,
+			},
+		},
+		{
+			name: "protected owner missing from members.yaml",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "bob", Role: MemberRoleMember},
+				},
+			},
+			protectedOwners: []string{"alice"},
+			wantErrors: []string{
+				`protected owner "alice" is missing from members.yaml: protected identities cannot be removed`,
+			},
+		},
+		{
+			name: "protected owner demoted to member",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleMember},
+				},
+			},
+			protectedOwners: []string{"alice"},
+			wantErrors: []string{
+				`protected owner "alice" has role "member": protected identities cannot be demoted from owner`,
+			},
+		},
+		{
+			name: "multiple violations all reported in one call",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleMember, Teams: []string{"ghost"}},
+					{Username: "alice", Role: MemberRoleMember},
+				},
+			},
+			protectedOwners: []string{"dave"},
+			wantErrors: []string{
+				`member "alice" references team "ghost" which is not defined in teams.yaml`,
+				`member "alice" is defined more than once in members.yaml`,
+				`protected owner "dave" is missing from members.yaml: protected identities cannot be removed`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.config.Validate(knownTeams, tt.protectedOwners)
+
+			var got []string
+			for _, err := range errs {
+				got = append(got, err.Error())
+			}
+			assert.Equal(t, tt.wantErrors, got)
+		})
+	}
+}

--- a/feature/github-repo-provisioning/members.tf
+++ b/feature/github-repo-provisioning/members.tf
@@ -1,0 +1,37 @@
+locals {
+  members_config_files = fileset(path.module, "gcss_config/organisation/members.yaml")
+
+  members_content = length(local.members_config_files) > 0 ? file("${path.module}/gcss_config/organisation/members.yaml") : "members: []"
+
+  members_raw = yamldecode(trimspace(local.members_content) == "" ? "members: []" : local.members_content)
+
+  members_list = try([for m in local.members_raw.members : m if m != null], [])
+
+  members_by_username = { for m in local.members_list : m.username => m }
+
+  member_team_pairs = {
+    for pair in flatten([
+      for username, m in local.members_by_username : try([
+        for team in m.teams : {
+          username = username
+          team     = team
+        }
+      ], [])
+    ]) : "${pair.username}/${pair.team}" => pair
+  }
+}
+
+resource "github_membership" "member" {
+  for_each = local.members_by_username
+
+  username = each.value.username
+  role     = try(each.value.role, "member") == "owner" ? "admin" : "member"
+}
+
+resource "github_team_membership" "membership" {
+  for_each = local.member_team_pairs
+
+  team_id  = github_team.team[each.value.team].id
+  username = each.value.username
+  role     = "member"
+}

--- a/feature/github-repo-provisioning/members.tf
+++ b/feature/github-repo-provisioning/members.tf
@@ -14,7 +14,8 @@ locals {
       for username, m in local.members_by_username : try([
         for team in m.teams : {
           username = username
-          team     = team
+          team     = team.name
+          role     = try(team.role, "member")
         }
       ], [])
     ]) : "${pair.username}/${pair.team}" => pair
@@ -33,5 +34,5 @@ resource "github_team_membership" "membership" {
 
   team_id  = github_team.team[each.value.team].id
   username = each.value.username
-  role     = "member"
+  role     = each.value.role
 }


### PR DESCRIPTION
Implements GCSS-1390.

## What this does

Brings organisation **members** under GCSS. Membership is now described in `organisation/members.yaml` and reconciled by Terraform — the same config-as-code model already used for repositories and teams.

Each member entry:

| Field | Notes |
|---|---|
| `username` | required |
| `role` | `owner` or `member` — defaults to `member` |
| `teams` | list of team names the member belongs to |

The YAML uses the friendly GitHub-UI wording; GCSS translates it to the provider's arguments:

- `role: owner` → `github_membership.role = admin`; `role: member` → `member`
- each `teams` entry becomes a `github_team_membership` (role `member`)

Team membership is owned **member-side** here — a team's roster is derived from the members who list it, not declared in `teams.yaml`.

## What's included

- **Schema + Go model** for `members.yaml`, generated from the structs and kept honest by the CI check.
- **`github_membership.member`** — one `for_each` over members, translating `owner → admin`.
- **`github_team_membership.membership`** — one `for_each` over the flattened `members × teams` pairs, referencing the teams defined in `teams.yaml`.
- **Validation** (library): rejects duplicate usernames, team references that don't exist in `teams.yaml`, and any change that would remove or demote a protected owner. The protected-owner set is passed in, so the actual list stays deployment config rather than code.

## Testing

Verified against a testing org:

- `terraform console` — role translation (`owner→admin`), the member→team-membership expansion, and the null/empty-YAML edge cases (`members:` null, empty file, null list entry, `teams:` null) all behave correctly.
- `terraform plan` — members, teams, and the flattened team-memberships all plan cleanly; the provider accepts every argument.

No live apply/destroy this time: memberships act on real user accounts (there's no throwaway user to create and delete, unlike teams), so plan + console validation is the bar here.

## Not wired up yet (by design)

- **Validation isn't run pre-plan yet** — the `Validate()` logic is built and unit-tested as a library; wiring it into the pre-plan check (and deciding where the protected-owner list comes from) belongs to the org-config validation work.
- **Not safe to apply to a populated org yet** — that needs the bootstrap importer to seed `members.yaml` from the live org first; otherwise the first apply, seeing an empty roster, would try to remove existing members. Same dormant status as the teams work.

## Follow-ups (tracked separately)

- Bootstrap importer to seed the `organisation/` config from the live org.
- Wiring the schema + validation into the pre-plan check, with CODEOWNERS gating.
