### PR TITLE
schema: enforce description <=350 chars and has_downloads=false

### DIFF
--- a/.schemas/repository-config.schema.json
+++ b/.schemas/repository-config.schema.json
@@ -314,7 +314,8 @@
     "RepositoryWithExpansionConfig": {
       "properties": {
         "description": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 350
         },
         "visibility": {
           "type": "string",
@@ -339,7 +340,8 @@
           "type": "boolean"
         },
         "has_downloads": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": false
         },
         "allow_merge_commit": {
           "type": "boolean"

--- a/feature/github-repo-importer/cmd/schema.go
+++ b/feature/github-repo-importer/cmd/schema.go
@@ -129,6 +129,13 @@ func BuildRepositoryConfigSchema() *jsonschema.Schema {
 					prop.Deprecated = true
 				}
 			}
+			// GitHub removed the legacy repository "Downloads" feature (2012) and no
+			// longer allows has_downloads to be enabled; the API silently keeps it
+			// false. Pin the config to false so a stray `true` fails validation
+			// instead of producing perpetual drift.
+			if prop, exists := repoDef.Properties.Get("has_downloads"); exists {
+				prop.Const = false
+			}
 		}
 
 		pagesDef, ok := schema.Definitions["Pages"]

--- a/feature/github-repo-importer/cmd/validate_test.go
+++ b/feature/github-repo-importer/cmd/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -57,6 +58,32 @@ func TestValidate_SchemaViolationCitesFileAndPath(t *testing.T) {
 	assert.Contains(t, out, filepath.Join(dir, "repos", "bad.yaml"))
 	assert.Contains(t, out, "/visibility")
 	assert.Contains(t, out, "/has_issues")
+}
+
+func TestValidate_DescriptionOver350Rejected(t *testing.T) {
+	long := strings.Repeat("x", 351)
+	dir := newConfigDir(t, map[string]string{
+		"bad.yaml": "default_branch: main\nvisibility: public\ndescription: " + long + "\n",
+	})
+
+	out, err := runValidateCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, "/description")
+}
+
+func TestValidate_HasDownloadsTrueRejected(t *testing.T) {
+	dir := newConfigDir(t, map[string]string{
+		"bad.yaml":  "default_branch: main\nvisibility: public\nhas_downloads: true\n",
+		"good.yaml": "default_branch: main\nvisibility: public\nhas_downloads: false\n",
+	})
+
+	out, err := runValidateCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, "/has_downloads")
+	assert.Contains(t, out, filepath.Join(dir, "repos", "bad.yaml"))
+	assert.NotContains(t, out, filepath.Join("repos", "good.yaml")+":")
 }
 
 func TestValidate_YmlExtensionIsValidated(t *testing.T) {

--- a/feature/github-repo-importer/pkg/github/repositories.go
+++ b/feature/github-repo-importer/pkg/github/repositories.go
@@ -3,7 +3,7 @@ package github
 type Repository struct {
 	Name                       string                `yaml:"-"`
 	Owner                      string                `yaml:"-"`
-	Description                *string               `yaml:"description,omitempty"`
+	Description                *string               `yaml:"description,omitempty" jsonschema:"maxLength=350"`
 	Visibility                 string                `yaml:"visibility,omitempty" jsonschema:"enum=public,enum=private"`
 	HomepageURL                *string               `yaml:"homepage_url,omitempty"`
 	DefaultBranch              string                `yaml:"default_branch,omitempty" jsonschema:"required"`


### PR DESCRIPTION
Encodes two GitHub-imposed constraints into the repo-config schema so the existing `validate` step catches them at PR time instead of failing at `terraform apply`:

- **description**: `maxLength: 350` (GitHub rejects longer with a 422).
- **has_downloads**: `const: false` (GitHub removed the legacy Downloads feature and won't let it be `true`).

Changes: `maxLength` tag on `Description`; `const: false` set programmatically in `schema.go` (invopop drops `enum` tags on bools); regenerated schema; tests for both rules.

Rollout: needs a github-terraformer release + a github-configuration ref bump (`v0.2.5` → new tag) for enforcement to land.