### PR TITLE
GCSS-1391: validate organisation/*.yaml before plan

### DIFF
--- a/.github/actions/validate-org-configs/action.yaml
+++ b/.github/actions/validate-org-configs/action.yaml
@@ -1,0 +1,43 @@
+name: "Validate organisation configuration files"
+description: "Validates organisation/teams.yaml and organisation/members.yaml against schema and cross-file rules, failing fast before Terraform runs"
+inputs:
+  config-path:
+    description: "Path to the configuration repository containing organisation/*.yaml files to validate"
+    required: true
+  protected-owners:
+    description: "Comma-separated org logins that must stay owners (never removed or demoted). Sourced from deployment config, not the config repo."
+    required: false
+    default: ""
+  fallback-schema-teams:
+    description: "Workspace-relative path to the fallback teams schema. Defaults to the schema bundled with github-terraformer."
+    required: false
+    default: ".schemas/teams-config.schema.json"
+  fallback-schema-members:
+    description: "Workspace-relative path to the fallback members schema. Defaults to the schema bundled with github-terraformer."
+    required: false
+    default: ".schemas/members-config.schema.json"
+  importer-path:
+    description: "Path to the github-repo-importer Go module"
+    required: false
+    default: "feature/github-repo-importer"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      with:
+        go-version-file: ${{ inputs.importer-path }}/go.mod
+
+    - name: Validate organisation/*.yaml against schema and rules
+      shell: bash
+      working-directory: ${{ inputs.importer-path }}
+      env:
+        FALLBACK_TEAMS: ${{ format('{0}/{1}', github.workspace, inputs.fallback-schema-teams != '' && inputs.fallback-schema-teams || '.schemas/teams-config.schema.json') }}
+        FALLBACK_MEMBERS: ${{ format('{0}/{1}', github.workspace, inputs.fallback-schema-members != '' && inputs.fallback-schema-members || '.schemas/members-config.schema.json') }}
+        PROTECTED_OWNERS: ${{ inputs.protected-owners }}
+      run: |
+        go run . validate-org \
+          --config-dir "${{ github.workspace }}/${{ inputs.config-path }}" \
+          --protected-owners "$PROTECTED_OWNERS" \
+          --fallback-schema-teams "$FALLBACK_TEAMS" \
+          --fallback-schema-members "$FALLBACK_MEMBERS"

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -21,6 +21,11 @@ on:
         description: "Workspace-relative path to the fallback JSON schema for repos/*.yaml validation, used when the config repo provides no override (e.g. 'gcss_config/.schemas/my.schema.json'). When omitted, the schema bundled with github-terraformer is used."
         required: false
         default: ""
+      protected_owners:
+        type: string
+        description: "Comma-separated org logins that must stay owners in organisation/members.yaml (never removed or demoted). Sourced from deployment config (e.g. a repo variable), not the config repo."
+        required: false
+        default: ""
     secrets:
       app_private_key:
         required: true
@@ -55,6 +60,12 @@ jobs:
         with:
           config-path: gcss_config
           fallback-schema-path: ${{ inputs.fallback_schema_path }}
+
+      - name: Validate organisation/*.yaml
+        uses: ./.github/actions/validate-org-configs
+        with:
+          config-path: gcss_config
+          protected-owners: ${{ inputs.protected_owners }}
 
   terraform-plan:
     needs: validate

--- a/.schemas/members-config.schema.json
+++ b/.schemas/members-config.schema.json
@@ -6,7 +6,8 @@
     "Member": {
       "properties": {
         "username": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "role": {
           "type": "string",
@@ -43,7 +44,8 @@
     "TeamMembership": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "role": {
           "type": "string",

--- a/.schemas/teams-config.schema.json
+++ b/.schemas/teams-config.schema.json
@@ -6,7 +6,8 @@
     "Team": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "slug": {
           "type": "string",

--- a/feature/github-repo-importer/cmd/validate-org.go
+++ b/feature/github-repo-importer/cmd/validate-org.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gr-oss-devops/github-repo-importer/pkg/github"
+)
+
+var (
+	validateOrgConfigDir       string
+	validateOrgProtectedOwners string
+	validateOrgFallbackTeams   string
+	validateOrgFallbackMembers string
+)
+
+var validateOrgCmd = &cobra.Command{
+	Use:   "validate-org",
+	Short: "Validate organisation/teams.yaml and organisation/members.yaml before Terraform runs",
+	Long: `ValidateOrg validates organisation/teams.yaml and organisation/members.yaml in
+the config directory, failing fast before Terraform runs. Each file is checked
+against its JSON schema and against cross-file rules the schema cannot express:
+
+  - duplicate team names / duplicate team memberships
+  - a member referencing a team not defined in teams.yaml
+  - a protected owner being removed or demoted (--protected-owners)
+
+Either file may be absent; validation runs on whichever exist.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runValidateOrg(cmd, validateOrgConfigDir, validateOrgProtectedOwners, validateOrgFallbackTeams, validateOrgFallbackMembers)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateOrgCmd)
+
+	validateOrgCmd.Flags().StringVar(&validateOrgConfigDir, "config-dir", "", "Path to the config repository containing organisation/*.yaml")
+	validateOrgCmd.Flags().StringVar(&validateOrgProtectedOwners, "protected-owners", "", "Comma-separated org logins that must stay owners (never removed or demoted)")
+	validateOrgCmd.Flags().StringVar(&validateOrgFallbackTeams, "fallback-schema-teams", "", "Fallback teams schema path used when no built-in schema is wanted")
+	validateOrgCmd.Flags().StringVar(&validateOrgFallbackMembers, "fallback-schema-members", "", "Fallback members schema path used when no built-in schema is wanted")
+	_ = validateOrgCmd.MarkFlagRequired("config-dir")
+}
+
+func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackTeams, fallbackMembers string) error {
+	teamsPath := filepath.Join(configDir, "organisation", "teams.yaml")
+	membersPath := filepath.Join(configDir, "organisation", "members.yaml")
+
+	teamsExists := fileExists(teamsPath)
+	membersExists := fileExists(membersPath)
+
+	if !teamsExists && !membersExists {
+		cmd.Println("No organisation/teams.yaml or organisation/members.yaml found, skipping validation")
+		return nil
+	}
+
+	var failures []string
+	var teamNames []string
+
+	if teamsExists {
+		schema, err := compileSchema("mem://teams-config.schema.json", fallbackTeams, MarshalTeamsConfigSchema)
+		if err != nil {
+			return err
+		}
+		failures = append(failures, validateFile(teamsPath, schema)...)
+
+		var teamsCfg github.TeamsConfig
+		if err := unmarshalYAMLFile(teamsPath, &teamsCfg); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", teamsPath, err))
+		} else {
+			for _, e := range teamsCfg.Validate() {
+				failures = append(failures, fmt.Sprintf("%s: %v", teamsPath, e))
+			}
+			for _, t := range teamsCfg.Teams {
+				teamNames = append(teamNames, t.Name)
+			}
+		}
+	}
+
+	if membersExists {
+		schema, err := compileSchema("mem://members-config.schema.json", fallbackMembers, MarshalMembersConfigSchema)
+		if err != nil {
+			return err
+		}
+		failures = append(failures, validateFile(membersPath, schema)...)
+
+		var membersCfg github.MembersConfig
+		if err := unmarshalYAMLFile(membersPath, &membersCfg); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", membersPath, err))
+		} else {
+			for _, e := range membersCfg.Validate(teamNames, splitCSV(protectedOwnersCSV)) {
+				failures = append(failures, fmt.Sprintf("%s: %v", membersPath, e))
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		cmd.PrintErrln("\nOrganisation config validation errors were encountered:")
+		for _, f := range failures {
+			cmd.PrintErrf("  %s\n", f)
+		}
+		return fmt.Errorf("organisation config validation failed")
+	}
+
+	cmd.Println("ok -- organisation config")
+	return nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func unmarshalYAMLFile(path string, out any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("invalid YAML: %w", err)
+	}
+	return nil
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/feature/github-repo-importer/cmd/validate-org.go
+++ b/feature/github-repo-importer/cmd/validate-org.go
@@ -176,23 +176,32 @@ func validateMembersFiles(cmd *cobra.Command, paths []string, fallbackSchema str
 			loadedAll = false
 			continue
 		}
+
+		// Structural rules are per file: checking them on the merged set would hide
+		// a duplicate that the other file happens to override.
+		if teamsOK {
+			for _, e := range cfg.ValidateEntries(teamNames) {
+				*failures = append(*failures, fmt.Sprintf("%s: %v", path, e))
+			}
+		}
+
 		merged = mergeMembers(merged, cfg)
 	}
 
+	if !teamsOK {
+		cmd.PrintErrln("WARNING: skipping member team-reference checks until the teams config loads")
+	}
 	if !loadedAll {
 		return
 	}
 
-	if !teamsOK {
-		cmd.PrintErrln("WARNING: skipping member checks until the teams config loads")
-		return
-	}
-
+	// Protected owners are genuinely cross-file: an owner may be declared in either
+	// the promoted or the staged file, so this runs on the effective member set.
 	label := "organisation members config"
 	if len(paths) > 0 {
 		label = strings.Join(paths, " + ")
 	}
-	for _, e := range merged.Validate(teamNames, protectedOwners) {
+	for _, e := range merged.ValidateProtectedOwners(protectedOwners) {
 		*failures = append(*failures, fmt.Sprintf("%s: %v", label, e))
 	}
 }

--- a/feature/github-repo-importer/cmd/validate-org.go
+++ b/feature/github-repo-importer/cmd/validate-org.go
@@ -12,6 +12,14 @@ import (
 	"github.com/gr-oss-devops/github-repo-importer/pkg/github"
 )
 
+// orgConfigDir holds the promoted organisation config; stagedOrgConfigDir holds
+// the importer's not-yet-promoted output. Terraform merges both, so both are
+// validated.
+const (
+	orgConfigDir       = "organisation"
+	stagedOrgConfigDir = "importer_tmp_dir/organisation"
+)
+
 var (
 	validateOrgConfigDir       string
 	validateOrgProtectedOwners string
@@ -21,16 +29,22 @@ var (
 
 var validateOrgCmd = &cobra.Command{
 	Use:   "validate-org",
-	Short: "Validate organisation/teams.yaml and organisation/members.yaml before Terraform runs",
-	Long: `ValidateOrg validates organisation/teams.yaml and organisation/members.yaml in
-the config directory, failing fast before Terraform runs. Each file is checked
-against its JSON schema and against cross-file rules the schema cannot express:
+	Short: "Validate organisation teams.yaml and members.yaml before Terraform runs",
+	Long: `ValidateOrg validates the organisation teams.yaml and members.yaml in the
+config directory, failing fast before Terraform runs. Files are read from both
+organisation/ and importer_tmp_dir/organisation/ and merged the same way the
+Terraform config merges them, so staged bootstrap output is validated too.
+
+Each file is checked against its JSON schema and against rules the schema cannot
+express:
 
   - duplicate team names / duplicate team memberships
   - a member referencing a team not defined in teams.yaml
   - a protected owner being removed or demoted (--protected-owners)
 
-Either file may be absent; validation runs on whichever exist.`,
+Files may be absent. An absent members.yaml is treated as an empty member list,
+matching how Terraform reads it, so protected owners are enforced even when the
+file is deleted outright.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runValidateOrg(cmd, validateOrgConfigDir, validateOrgProtectedOwners, validateOrgFallbackTeams, validateOrgFallbackMembers)
@@ -40,7 +54,7 @@ Either file may be absent; validation runs on whichever exist.`,
 func init() {
 	rootCmd.AddCommand(validateOrgCmd)
 
-	validateOrgCmd.Flags().StringVar(&validateOrgConfigDir, "config-dir", "", "Path to the config repository containing organisation/*.yaml")
+	validateOrgCmd.Flags().StringVar(&validateOrgConfigDir, "config-dir", "", "Path to the config repository containing the organisation config")
 	validateOrgCmd.Flags().StringVar(&validateOrgProtectedOwners, "protected-owners", "", "Comma-separated org logins that must stay owners (never removed or demoted)")
 	validateOrgCmd.Flags().StringVar(&validateOrgFallbackTeams, "fallback-schema-teams", "", "Fallback teams schema path used when no built-in schema is wanted")
 	validateOrgCmd.Flags().StringVar(&validateOrgFallbackMembers, "fallback-schema-members", "", "Fallback members schema path used when no built-in schema is wanted")
@@ -48,55 +62,63 @@ func init() {
 }
 
 func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackTeams, fallbackMembers string) error {
-	teamsPath := filepath.Join(configDir, "organisation", "teams.yaml")
-	membersPath := filepath.Join(configDir, "organisation", "members.yaml")
+	teamsFiles := existingFiles(
+		filepath.Join(configDir, stagedOrgConfigDir, "teams.yaml"),
+		filepath.Join(configDir, orgConfigDir, "teams.yaml"),
+	)
+	membersFiles := existingFiles(
+		filepath.Join(configDir, stagedOrgConfigDir, "members.yaml"),
+		filepath.Join(configDir, orgConfigDir, "members.yaml"),
+	)
 
-	teamsExists := fileExists(teamsPath)
-	membersExists := fileExists(membersPath)
-
-	if !teamsExists && !membersExists {
-		cmd.Println("No organisation/teams.yaml or organisation/members.yaml found, skipping validation")
-		return nil
+	if len(teamsFiles) == 0 && len(membersFiles) == 0 {
+		cmd.Println("No organisation teams.yaml or members.yaml found, checking protected owners only")
 	}
 
 	var failures []string
 	var teamNames []string
 
-	if teamsExists {
+	if len(teamsFiles) > 0 {
 		schema, err := compileSchema("mem://teams-config.schema.json", fallbackTeams, MarshalTeamsConfigSchema)
 		if err != nil {
 			return err
 		}
-		failures = append(failures, validateFile(teamsPath, schema)...)
+		for _, path := range teamsFiles {
+			failures = append(failures, validateFile(path, schema)...)
 
-		var teamsCfg github.TeamsConfig
-		if err := unmarshalYAMLFile(teamsPath, &teamsCfg); err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", teamsPath, err))
-		} else {
-			for _, e := range teamsCfg.Validate() {
-				failures = append(failures, fmt.Sprintf("%s: %v", teamsPath, e))
+			var cfg github.TeamsConfig
+			if err := unmarshalYAMLFile(path, &cfg); err != nil {
+				failures = append(failures, fmt.Sprintf("%s: %v", path, err))
+				continue
 			}
-			for _, t := range teamsCfg.Teams {
+			for _, e := range cfg.Validate() {
+				failures = append(failures, fmt.Sprintf("%s: %v", path, e))
+			}
+			for _, t := range cfg.Teams {
 				teamNames = append(teamNames, t.Name)
 			}
 		}
 	}
 
-	if membersExists {
+	if len(membersFiles) > 0 {
 		schema, err := compileSchema("mem://members-config.schema.json", fallbackMembers, MarshalMembersConfigSchema)
 		if err != nil {
 			return err
 		}
-		failures = append(failures, validateFile(membersPath, schema)...)
-
-		var membersCfg github.MembersConfig
-		if err := unmarshalYAMLFile(membersPath, &membersCfg); err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", membersPath, err))
-		} else {
-			for _, e := range membersCfg.Validate(teamNames, splitCSV(protectedOwnersCSV)) {
-				failures = append(failures, fmt.Sprintf("%s: %v", membersPath, e))
-			}
+		for _, path := range membersFiles {
+			failures = append(failures, validateFile(path, schema)...)
 		}
+	}
+
+	merged, loadErrs := loadMergedMembers(membersFiles)
+	failures = append(failures, loadErrs...)
+
+	label := "organisation members config"
+	if len(membersFiles) > 0 {
+		label = strings.Join(membersFiles, " + ")
+	}
+	for _, e := range merged.Validate(teamNames, splitCSV(protectedOwnersCSV)) {
+		failures = append(failures, fmt.Sprintf("%s: %v", label, e))
 	}
 
 	if len(failures) > 0 {
@@ -111,9 +133,60 @@ func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackT
 	return nil
 }
 
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+// loadMergedMembers merges the given members files the same way the Terraform
+// config does: later files win per username. With a single file the entries are
+// returned as-is, so duplicates within that file are still reported.
+func loadMergedMembers(paths []string) (github.MembersConfig, []string) {
+	var failures []string
+	var configs []github.MembersConfig
+
+	for _, path := range paths {
+		var cfg github.MembersConfig
+		if err := unmarshalYAMLFile(path, &cfg); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", path, err))
+			continue
+		}
+		configs = append(configs, cfg)
+	}
+
+	merged := github.MembersConfig{}
+	for _, cfg := range configs {
+		merged = mergeMembers(merged, cfg)
+	}
+	return merged, failures
+}
+
+func mergeMembers(base, override github.MembersConfig) github.MembersConfig {
+	if len(base.Members) == 0 {
+		return override
+	}
+	if len(override.Members) == 0 {
+		return base
+	}
+
+	overridden := make(map[string]struct{}, len(override.Members))
+	for _, m := range override.Members {
+		overridden[m.Username] = struct{}{}
+	}
+
+	merged := make([]github.Member, 0, len(base.Members)+len(override.Members))
+	for _, m := range base.Members {
+		if _, replaced := overridden[m.Username]; !replaced {
+			merged = append(merged, m)
+		}
+	}
+	merged = append(merged, override.Members...)
+	return github.MembersConfig{Members: merged}
+}
+
+func existingFiles(paths ...string) []string {
+	var out []string
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			out = append(out, path)
+		}
+	}
+	return out
 }
 
 func unmarshalYAMLFile(path string, out any) error {

--- a/feature/github-repo-importer/cmd/validate-org.go
+++ b/feature/github-repo-importer/cmd/validate-org.go
@@ -13,9 +13,6 @@ import (
 	"github.com/gr-oss-devops/github-repo-importer/pkg/github"
 )
 
-// orgConfigDir holds the promoted organisation config; stagedOrgConfigDir holds
-// the importer's not-yet-promoted output. Terraform merges both, so both are
-// validated.
 const (
 	orgConfigDir       = "organisation"
 	stagedOrgConfigDir = "importer_tmp_dir/organisation"
@@ -105,9 +102,7 @@ func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackT
 }
 
 // validateTeamsFiles returns the team names declared across the given files and
-// whether every file loaded. A failed load leaves teamNames incomplete, which
-// would turn every member team reference into a bogus error, so callers use the
-// second return value to suppress that check.
+// whether every file loaded.
 func validateTeamsFiles(cmd *cobra.Command, paths []string, fallbackSchema string, failures *[]string) ([]string, bool) {
 	if len(paths) == 0 {
 		return nil, true
@@ -177,8 +172,6 @@ func validateMembersFiles(cmd *cobra.Command, paths []string, fallbackSchema str
 			continue
 		}
 
-		// Structural rules are per file: checking them on the merged set would hide
-		// a duplicate that the other file happens to override.
 		if teamsOK {
 			for _, e := range cfg.ValidateEntries(teamNames) {
 				*failures = append(*failures, fmt.Sprintf("%s: %v", path, e))
@@ -195,8 +188,6 @@ func validateMembersFiles(cmd *cobra.Command, paths []string, fallbackSchema str
 		return
 	}
 
-	// Protected owners are genuinely cross-file: an owner may be declared in either
-	// the promoted or the staged file, so this runs on the effective member set.
 	label := "organisation members config"
 	if len(paths) > 0 {
 		label = strings.Join(paths, " + ")
@@ -207,8 +198,7 @@ func validateMembersFiles(cmd *cobra.Command, paths []string, fallbackSchema str
 }
 
 // mergeMembers merges two member sets the way the Terraform config does: override
-// wins per username. When only one side has entries it is returned as-is, so
-// duplicates within a single file are still reported.
+// wins per username.
 func mergeMembers(base, override github.MembersConfig) github.MembersConfig {
 	if len(base.Members) == 0 {
 		return override

--- a/feature/github-repo-importer/cmd/validate-org.go
+++ b/feature/github-repo-importer/cmd/validate-org.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -44,7 +45,11 @@ express:
 
 Files may be absent. An absent members.yaml is treated as an empty member list,
 matching how Terraform reads it, so protected owners are enforced even when the
-file is deleted outright.`,
+file is deleted outright.
+
+Unlike repository config, the schema is never taken from the config repository:
+both the schema and the protected-owner list are deployment config, so a pull
+request cannot weaken the rules it is validated against.`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runValidateOrg(cmd, validateOrgConfigDir, validateOrgProtectedOwners, validateOrgFallbackTeams, validateOrgFallbackMembers)
@@ -56,8 +61,8 @@ func init() {
 
 	validateOrgCmd.Flags().StringVar(&validateOrgConfigDir, "config-dir", "", "Path to the config repository containing the organisation config")
 	validateOrgCmd.Flags().StringVar(&validateOrgProtectedOwners, "protected-owners", "", "Comma-separated org logins that must stay owners (never removed or demoted)")
-	validateOrgCmd.Flags().StringVar(&validateOrgFallbackTeams, "fallback-schema-teams", "", "Fallback teams schema path used when no built-in schema is wanted")
-	validateOrgCmd.Flags().StringVar(&validateOrgFallbackMembers, "fallback-schema-members", "", "Fallback members schema path used when no built-in schema is wanted")
+	validateOrgCmd.Flags().StringVar(&validateOrgFallbackTeams, "fallback-schema-teams", "", "Path to the teams schema to validate against; defaults to the schema built into this binary")
+	validateOrgCmd.Flags().StringVar(&validateOrgFallbackMembers, "fallback-schema-members", "", "Path to the members schema to validate against; defaults to the schema built into this binary")
 	_ = validateOrgCmd.MarkFlagRequired("config-dir")
 }
 
@@ -71,55 +76,21 @@ func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackT
 		filepath.Join(configDir, orgConfigDir, "members.yaml"),
 	)
 
+	protectedOwners := splitCSV(protectedOwnersCSV)
+	if len(protectedOwners) > 0 {
+		cmd.Printf("Enforcing %d protected owner(s): %s\n", len(protectedOwners), strings.Join(protectedOwners, ", "))
+	} else {
+		cmd.PrintErrln("WARNING: no protected owners configured, owner removal and demotion are not enforced")
+	}
+
 	if len(teamsFiles) == 0 && len(membersFiles) == 0 {
-		cmd.Println("No organisation teams.yaml or members.yaml found, checking protected owners only")
+		cmd.Println("No organisation teams.yaml or members.yaml found, validating as an empty organisation config")
 	}
 
 	var failures []string
-	var teamNames []string
 
-	if len(teamsFiles) > 0 {
-		schema, err := compileSchema("mem://teams-config.schema.json", fallbackTeams, MarshalTeamsConfigSchema)
-		if err != nil {
-			return err
-		}
-		for _, path := range teamsFiles {
-			failures = append(failures, validateFile(path, schema)...)
-
-			var cfg github.TeamsConfig
-			if err := unmarshalYAMLFile(path, &cfg); err != nil {
-				failures = append(failures, fmt.Sprintf("%s: %v", path, err))
-				continue
-			}
-			for _, e := range cfg.Validate() {
-				failures = append(failures, fmt.Sprintf("%s: %v", path, e))
-			}
-			for _, t := range cfg.Teams {
-				teamNames = append(teamNames, t.Name)
-			}
-		}
-	}
-
-	if len(membersFiles) > 0 {
-		schema, err := compileSchema("mem://members-config.schema.json", fallbackMembers, MarshalMembersConfigSchema)
-		if err != nil {
-			return err
-		}
-		for _, path := range membersFiles {
-			failures = append(failures, validateFile(path, schema)...)
-		}
-	}
-
-	merged, loadErrs := loadMergedMembers(membersFiles)
-	failures = append(failures, loadErrs...)
-
-	label := "organisation members config"
-	if len(membersFiles) > 0 {
-		label = strings.Join(membersFiles, " + ")
-	}
-	for _, e := range merged.Validate(teamNames, splitCSV(protectedOwnersCSV)) {
-		failures = append(failures, fmt.Sprintf("%s: %v", label, e))
-	}
+	teamNames, teamsOK := validateTeamsFiles(cmd, teamsFiles, fallbackTeams, &failures)
+	validateMembersFiles(cmd, membersFiles, fallbackMembers, teamNames, teamsOK, protectedOwners, &failures)
 
 	if len(failures) > 0 {
 		cmd.PrintErrln("\nOrganisation config validation errors were encountered:")
@@ -133,29 +104,102 @@ func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackT
 	return nil
 }
 
-// loadMergedMembers merges the given members files the same way the Terraform
-// config does: later files win per username. With a single file the entries are
-// returned as-is, so duplicates within that file are still reported.
-func loadMergedMembers(paths []string) (github.MembersConfig, []string) {
-	var failures []string
-	var configs []github.MembersConfig
+// validateTeamsFiles returns the team names declared across the given files and
+// whether every file loaded. A failed load leaves teamNames incomplete, which
+// would turn every member team reference into a bogus error, so callers use the
+// second return value to suppress that check.
+func validateTeamsFiles(cmd *cobra.Command, paths []string, fallbackSchema string, failures *[]string) ([]string, bool) {
+	if len(paths) == 0 {
+		return nil, true
+	}
 
+	schema, err := compileSchema("mem://teams-config.schema.json", fallbackSchema, MarshalTeamsConfigSchema)
+	if err != nil {
+		*failures = append(*failures, fmt.Sprintf("teams schema: %v", err))
+		return nil, false
+	}
+
+	var teamNames []string
+	loadedAll := true
 	for _, path := range paths {
-		var cfg github.MembersConfig
-		if err := unmarshalYAMLFile(path, &cfg); err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", path, err))
+		data, instance, loadErr := loadYAMLDocument(path)
+		if loadErr != nil {
+			*failures = append(*failures, fmt.Sprintf("%s: %v", path, loadErr))
+			loadedAll = false
 			continue
 		}
-		configs = append(configs, cfg)
+		*failures = append(*failures, validateInstance(path, instance, schema)...)
+
+		var cfg github.TeamsConfig
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			*failures = append(*failures, fmt.Sprintf("%s: does not match the teams config shape: %v", path, err))
+			loadedAll = false
+			continue
+		}
+		for _, e := range cfg.Validate() {
+			*failures = append(*failures, fmt.Sprintf("%s: %v", path, e))
+		}
+		for _, t := range cfg.Teams {
+			teamNames = append(teamNames, t.Name)
+		}
+	}
+	return teamNames, loadedAll
+}
+
+func validateMembersFiles(cmd *cobra.Command, paths []string, fallbackSchema string, teamNames []string, teamsOK bool, protectedOwners []string, failures *[]string) {
+	var schema *jsonschema.Schema
+	if len(paths) > 0 {
+		compiled, err := compileSchema("mem://members-config.schema.json", fallbackSchema, MarshalMembersConfigSchema)
+		if err != nil {
+			*failures = append(*failures, fmt.Sprintf("members schema: %v", err))
+		} else {
+			schema = compiled
+		}
 	}
 
 	merged := github.MembersConfig{}
-	for _, cfg := range configs {
+	loadedAll := true
+	for _, path := range paths {
+		data, instance, loadErr := loadYAMLDocument(path)
+		if loadErr != nil {
+			*failures = append(*failures, fmt.Sprintf("%s: %v", path, loadErr))
+			loadedAll = false
+			continue
+		}
+		if schema != nil {
+			*failures = append(*failures, validateInstance(path, instance, schema)...)
+		}
+
+		var cfg github.MembersConfig
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			*failures = append(*failures, fmt.Sprintf("%s: does not match the members config shape: %v", path, err))
+			loadedAll = false
+			continue
+		}
 		merged = mergeMembers(merged, cfg)
 	}
-	return merged, failures
+
+	if !loadedAll {
+		return
+	}
+
+	if !teamsOK {
+		cmd.PrintErrln("WARNING: skipping member checks until the teams config loads")
+		return
+	}
+
+	label := "organisation members config"
+	if len(paths) > 0 {
+		label = strings.Join(paths, " + ")
+	}
+	for _, e := range merged.Validate(teamNames, protectedOwners) {
+		*failures = append(*failures, fmt.Sprintf("%s: %v", label, e))
+	}
 }
 
+// mergeMembers merges two member sets the way the Terraform config does: override
+// wins per username. When only one side has entries it is returned as-is, so
+// duplicates within a single file are still reported.
 func mergeMembers(base, override github.MembersConfig) github.MembersConfig {
 	if len(base.Members) == 0 {
 		return override
@@ -187,17 +231,6 @@ func existingFiles(paths ...string) []string {
 		}
 	}
 	return out
-}
-
-func unmarshalYAMLFile(path string, out any) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
-	}
-	if err := yaml.Unmarshal(data, out); err != nil {
-		return fmt.Errorf("invalid YAML: %w", err)
-	}
-	return nil
 }
 
 func splitCSV(s string) []string {

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -26,12 +27,36 @@ func newOrgConfigDir(t *testing.T, files map[string]string) string {
 
 func runValidateOrgCmd(t *testing.T, configDir, protectedOwners string) (string, error) {
 	t.Helper()
+	return runValidateOrgCmdWithSchemas(t, configDir, protectedOwners, "", "")
+}
+
+func runValidateOrgCmdWithSchemas(t *testing.T, configDir, protectedOwners, fallbackTeams, fallbackMembers string) (string, error) {
+	t.Helper()
 	var out bytes.Buffer
 	cmd := &cobra.Command{}
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	err := runValidateOrg(cmd, configDir, protectedOwners, "", "")
+	err := runValidateOrg(cmd, configDir, protectedOwners, fallbackTeams, fallbackMembers)
 	return out.String(), err
+}
+
+// writeGeneratedSchemas writes the generated schemas to disk so tests can exercise
+// the file-based path the composite action uses in CI, not just the built-in one.
+func writeGeneratedSchemas(t *testing.T) (teamsPath, membersPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	teamsRaw, err := MarshalTeamsConfigSchema()
+	require.NoError(t, err)
+	teamsPath = filepath.Join(dir, "teams-config.schema.json")
+	require.NoError(t, os.WriteFile(teamsPath, teamsRaw, 0o644))
+
+	membersRaw, err := MarshalMembersConfigSchema()
+	require.NoError(t, err)
+	membersPath = filepath.Join(dir, "members-config.schema.json")
+	require.NoError(t, os.WriteFile(membersPath, membersRaw, 0o644))
+
+	return teamsPath, membersPath
 }
 
 const validTeamsYAML = "teams:\n  - name: platform\n    visibility: visible\n  - name: security-core\n    visibility: secret\n"
@@ -117,7 +142,62 @@ func TestValidateOrg_ProtectedOwnersCSVParsed(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, out, `protected owner "bob" is missing from members.yaml`)
-	assert.NotContains(t, out, `"alice"`)
+	assert.NotContains(t, out, "protected owner \"alice\"", "alice satisfies the guard and must not be reported")
+	assert.Contains(t, out, "Enforcing 2 protected owner(s)")
+}
+
+func TestValidateOrg_WarnsWhenNoProtectedOwnersConfigured(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "WARNING: no protected owners configured")
+}
+
+func TestValidateOrg_FileBasedSchemasAreUsed(t *testing.T) {
+	teamsSchema, membersSchema := writeGeneratedSchemas(t)
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   "teams:\n  - name: platform\n    visibility: banana\n",
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmdWithSchemas(t, dir, "alice", teamsSchema, membersSchema)
+
+	require.Error(t, err)
+	assert.Contains(t, out, "/teams/0/visibility")
+}
+
+func TestValidateOrg_EmptyNamesRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   "teams:\n  - name: \"\"\n    visibility: visible\n",
+		"members.yaml": "members:\n  - username: \"\"\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, "/teams/0/name")
+	assert.Contains(t, out, "/members/0/username")
+}
+
+// A teams file that fails to parse leaves the known-team set empty, which would
+// otherwise turn every member team reference into a bogus error and bury the
+// real cause.
+func TestValidateOrg_BrokenTeamsFileDoesNotCascade(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   "teams: [oops\n",
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n    teams:\n      - name: platform\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, "invalid YAML")
+	assert.NotContains(t, out, `references team "platform"`, "team references must not be checked against an unparsed teams file")
+	assert.Equal(t, 1, strings.Count(out, "invalid YAML"), "the parse failure should be reported once, not once per validation layer")
 }
 
 func TestValidateOrg_NoFilesAndNoProtectedOwnersPasses(t *testing.T) {

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -154,6 +154,67 @@ func TestValidateOrg_BrokenTeamsFileStillEnforcesProtectedOwners(t *testing.T) {
 	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
 }
 
+// GitHub logins are case-insensitive, so these are one account. Left unflagged,
+// Terraform keys them separately and two resources manage one org membership.
+func TestValidateOrg_UsernameCaseCollisionRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n  - username: Alice\n    role: member\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `member "Alice" collides with "alice"`)
+}
+
+// Team names differing only in case slugify to the same GitHub team.
+func TestValidateOrg_TeamNameCaseCollisionRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml": "teams:\n  - name: platform\n    visibility: visible\n  - name: Platform\n    visibility: visible\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `team "Platform" collides with "platform"`)
+}
+
+func TestValidateOrg_ProtectedOwnerMatchedCaseInsensitively(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: GCSS-Bot\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "ok -- organisation config")
+}
+
+func TestValidateOrg_ProtectedOwnerDemotionCaughtRegardlessOfCase(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: GCSS-Bot\n    role: member\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "gcss-bot" has role "member"`)
+}
+
+// Terraform resolves a member's team as an exact map key, so a case-differing
+// reference must stay an error rather than be folded into a match.
+func TestValidateOrg_TeamReferenceMustMatchCaseExactly(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   "teams:\n  - name: platform\n    visibility: visible\n",
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n    teams:\n      - name: Platform\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `references team "Platform" but teams.yaml defines it as "platform"`)
+}
+
 func TestValidateOrg_ProtectedOwnerRemovedRejected(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml":   validTeamsYAML,

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -120,13 +120,110 @@ func TestValidateOrg_ProtectedOwnersCSVParsed(t *testing.T) {
 	assert.NotContains(t, out, `"alice"`)
 }
 
-func TestValidateOrg_NoFilesSkips(t *testing.T) {
+func TestValidateOrg_NoFilesAndNoProtectedOwnersPasses(t *testing.T) {
 	dir := t.TempDir()
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "ok -- organisation config")
+}
+
+// Terraform reads an absent members.yaml as an empty member list, so deleting
+// the file plans the same org-wide member wipe as emptying it. Both must fail.
+func TestValidateOrg_DeletedMembersFileStillEnforcesProtectedOwners(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml": validTeamsYAML,
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
+}
+
+func TestValidateOrg_EmptyMembersListEnforcesProtectedOwners(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members: []\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
+}
+
+// newStagedOrgConfigDir writes files to importer_tmp_dir/organisation/, where the
+// bootstrap importer stages output that Terraform merges into the applied set.
+func newStagedOrgConfigDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	stagedDir := filepath.Join(dir, "importer_tmp_dir", "organisation")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(stagedDir, name), []byte(content), 0o644))
+	}
+	return dir
+}
+
+func TestValidateOrg_StagedConfigIsSchemaValidated(t *testing.T) {
+	dir := newStagedOrgConfigDir(t, map[string]string{
+		"teams.yaml": "teams:\n  - name: platform\n    visibility: banana\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, filepath.Join("importer_tmp_dir", "organisation", "teams.yaml"))
+	assert.Contains(t, out, "/teams/0/visibility")
+}
+
+func TestValidateOrg_StagedMembersCrossFileRulesEnforced(t *testing.T) {
+	dir := newStagedOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n    teams:\n      - name: ghost\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `references team "ghost" which is not defined in teams.yaml`)
+	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
+}
+
+// A staged member may legitimately reference a team that is already promoted, so
+// team names from both locations must be visible to the reference check.
+func TestValidateOrg_StagedMembersResolveAgainstPromotedTeams(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml": validTeamsYAML,
+	})
+	stagedDir := filepath.Join(dir, "importer_tmp_dir", "organisation")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stagedDir, "members.yaml"),
+		[]byte("members:\n  - username: alice\n    role: owner\n    teams:\n      - name: platform\n"), 0o644))
 
 	out, err := runValidateOrgCmd(t, dir, "alice")
 
 	assert.NoError(t, err)
-	assert.Contains(t, out, "skipping validation")
+	assert.Contains(t, out, "ok -- organisation config")
+}
+
+// Terraform merges promoted over staged per username; the protected-owner check
+// must see the merged result, not either file alone.
+func TestValidateOrg_PromotedMemberOverridesStaged(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: member\n",
+	})
+	stagedDir := filepath.Join(dir, "importer_tmp_dir", "organisation")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stagedDir, "members.yaml"),
+		[]byte("members:\n  - username: alice\n    role: owner\n"), 0o644))
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "alice" has role "member"`)
 }
 
 func TestValidateOrg_MembersOnlyNoTeamsFile(t *testing.T) {

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newOrgConfigDir creates a temporary config directory containing the given
+// organisation/*.yaml files (name -> content). A nil/absent entry is skipped.
+func newOrgConfigDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	orgDir := filepath.Join(dir, "organisation")
+	require.NoError(t, os.MkdirAll(orgDir, 0o755))
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(orgDir, name), []byte(content), 0o644))
+	}
+	return dir
+}
+
+func runValidateOrgCmd(t *testing.T, configDir, protectedOwners string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := runValidateOrg(cmd, configDir, protectedOwners, "", "")
+	return out.String(), err
+}
+
+const validTeamsYAML = "teams:\n  - name: platform\n    visibility: visible\n  - name: security-core\n    visibility: secret\n"
+
+func TestValidateOrg_ValidConfigPasses(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n    teams:\n      - name: platform\n        role: maintainer\n  - username: bob\n    role: member\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "ok -- organisation config")
+}
+
+func TestValidateOrg_SchemaViolationCitesFileAndPath(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml": "teams:\n  - name: platform\n    visibility: banana\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, filepath.Join(dir, "organisation", "teams.yaml"))
+	assert.Contains(t, out, "/teams/0/visibility")
+}
+
+func TestValidateOrg_DuplicateTeamNameRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml": "teams:\n  - name: platform\n    visibility: visible\n  - name: platform\n    visibility: visible\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `team "platform" is defined more than once`)
+}
+
+func TestValidateOrg_MemberReferencesUnknownTeam(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n    teams:\n      - name: ghost\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `references team "ghost" which is not defined in teams.yaml`)
+}
+
+func TestValidateOrg_ProtectedOwnerRemovedRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members:\n  - username: bob\n    role: member\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "alice" is missing from members.yaml`)
+}
+
+func TestValidateOrg_ProtectedOwnerDemotedRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members:\n  - username: alice\n    role: member\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "alice" has role "member"`)
+}
+
+func TestValidateOrg_ProtectedOwnersCSVParsed(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
+	})
+
+	// bob is protected but absent; alice is protected and present as owner.
+	out, err := runValidateOrgCmd(t, dir, " alice , bob ")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `protected owner "bob" is missing from members.yaml`)
+	assert.NotContains(t, out, `"alice"`)
+}
+
+func TestValidateOrg_NoFilesSkips(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "skipping validation")
+}
+
+func TestValidateOrg_MembersOnlyNoTeamsFile(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "ok -- organisation config")
+}

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // newOrgConfigDir creates a temporary config directory containing the given
-// organisation/*.yaml files (name -> content). A nil/absent entry is skipped.
+// organisation/*.yaml files (name -> content).
 func newOrgConfigDir(t *testing.T, files map[string]string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -41,7 +41,7 @@ func runValidateOrgCmdWithSchemas(t *testing.T, configDir, protectedOwners, fall
 }
 
 // writeGeneratedSchemas writes the generated schemas to disk so tests can exercise
-// the file-based path the composite action uses in CI, not just the built-in one.
+// the file-based schema path.
 func writeGeneratedSchemas(t *testing.T) (teamsPath, membersPath string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -119,9 +119,6 @@ func TestValidateOrg_DuplicateUsernameRejected(t *testing.T) {
 	assert.Contains(t, out, `member "alice" is defined more than once`)
 }
 
-// Terraform keys the staged members by username on their own, so a duplicate in
-// the staged file is an error there regardless of what the promoted file declares.
-// Checking duplicates on the merged set would let the override hide it.
 func TestValidateOrg_DuplicateInStagedFileNotHiddenByPromotedOverride(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
@@ -139,8 +136,6 @@ func TestValidateOrg_DuplicateInStagedFileNotHiddenByPromotedOverride(t *testing
 		"the duplicate should be attributed to the staged file that contains it")
 }
 
-// The protected-owner rule does not depend on teams, so a teams file that fails to
-// parse must not hide an owner being removed.
 func TestValidateOrg_BrokenTeamsFileStillEnforcesProtectedOwners(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml":   "teams: [oops\n",
@@ -154,8 +149,6 @@ func TestValidateOrg_BrokenTeamsFileStillEnforcesProtectedOwners(t *testing.T) {
 	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
 }
 
-// GitHub logins are case-insensitive, so these are one account. Left unflagged,
-// Terraform keys them separately and two resources manage one org membership.
 func TestValidateOrg_UsernameCaseCollisionRejected(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"members.yaml": "members:\n  - username: alice\n    role: owner\n  - username: Alice\n    role: member\n",
@@ -167,7 +160,6 @@ func TestValidateOrg_UsernameCaseCollisionRejected(t *testing.T) {
 	assert.Contains(t, out, `member "Alice" collides with "alice"`)
 }
 
-// Team names differing only in case slugify to the same GitHub team.
 func TestValidateOrg_TeamNameCaseCollisionRejected(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml": "teams:\n  - name: platform\n    visibility: visible\n  - name: Platform\n    visibility: visible\n",
@@ -201,8 +193,6 @@ func TestValidateOrg_ProtectedOwnerDemotionCaughtRegardlessOfCase(t *testing.T) 
 	assert.Contains(t, out, `protected owner "gcss-bot" has role "member"`)
 }
 
-// Terraform resolves a member's team as an exact map key, so a case-differing
-// reference must stay an error rather than be folded into a match.
 func TestValidateOrg_TeamReferenceMustMatchCaseExactly(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml":   "teams:\n  - name: platform\n    visibility: visible\n",
@@ -244,7 +234,6 @@ func TestValidateOrg_ProtectedOwnersCSVParsed(t *testing.T) {
 		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
 	})
 
-	// bob is protected but absent; alice is protected and present as owner.
 	out, err := runValidateOrgCmd(t, dir, " alice , bob ")
 
 	require.Error(t, err)
@@ -290,9 +279,6 @@ func TestValidateOrg_EmptyNamesRejected(t *testing.T) {
 	assert.Contains(t, out, "/members/0/username")
 }
 
-// A teams file that fails to parse leaves the known-team set empty, which would
-// otherwise turn every member team reference into a bogus error and bury the
-// real cause.
 func TestValidateOrg_BrokenTeamsFileDoesNotCascade(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml":   "teams: [oops\n",
@@ -316,8 +302,6 @@ func TestValidateOrg_NoFilesAndNoProtectedOwnersPasses(t *testing.T) {
 	assert.Contains(t, out, "ok -- organisation config")
 }
 
-// Terraform reads an absent members.yaml as an empty member list, so deleting
-// the file plans the same org-wide member wipe as emptying it. Both must fail.
 func TestValidateOrg_DeletedMembersFileStillEnforcesProtectedOwners(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml": validTeamsYAML,
@@ -341,8 +325,7 @@ func TestValidateOrg_EmptyMembersListEnforcesProtectedOwners(t *testing.T) {
 	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
 }
 
-// newStagedOrgConfigDir writes files to importer_tmp_dir/organisation/, where the
-// bootstrap importer stages output that Terraform merges into the applied set.
+// newStagedOrgConfigDir writes files to importer_tmp_dir/organisation/.
 func newStagedOrgConfigDir(t *testing.T, files map[string]string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -379,8 +362,6 @@ func TestValidateOrg_StagedMembersCrossFileRulesEnforced(t *testing.T) {
 	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
 }
 
-// A staged member may legitimately reference a team that is already promoted, so
-// team names from both locations must be visible to the reference check.
 func TestValidateOrg_StagedMembersResolveAgainstPromotedTeams(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml": validTeamsYAML,
@@ -396,8 +377,6 @@ func TestValidateOrg_StagedMembersResolveAgainstPromotedTeams(t *testing.T) {
 	assert.Contains(t, out, "ok -- organisation config")
 }
 
-// Terraform merges promoted over staged per username; the protected-owner check
-// must see the merged result, not either file alone.
 func TestValidateOrg_PromotedMemberOverridesStaged(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"members.yaml": "members:\n  - username: alice\n    role: member\n",

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -108,6 +108,52 @@ func TestValidateOrg_MemberReferencesUnknownTeam(t *testing.T) {
 	assert.Contains(t, out, `references team "ghost" which is not defined in teams.yaml`)
 }
 
+func TestValidateOrg_DuplicateUsernameRejected(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n  - username: alice\n    role: member\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `member "alice" is defined more than once`)
+}
+
+// Terraform keys the staged members by username on their own, so a duplicate in
+// the staged file is an error there regardless of what the promoted file declares.
+// Checking duplicates on the merged set would let the override hide it.
+func TestValidateOrg_DuplicateInStagedFileNotHiddenByPromotedOverride(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
+	})
+	stagedDir := filepath.Join(dir, "importer_tmp_dir", "organisation")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stagedDir, "members.yaml"),
+		[]byte("members:\n  - username: alice\n    role: owner\n  - username: alice\n    role: member\n"), 0o644))
+
+	out, err := runValidateOrgCmd(t, dir, "alice")
+
+	require.Error(t, err)
+	assert.Contains(t, out, `member "alice" is defined more than once`)
+	assert.Contains(t, out, filepath.Join("importer_tmp_dir", "organisation", "members.yaml"),
+		"the duplicate should be attributed to the staged file that contains it")
+}
+
+// The protected-owner rule does not depend on teams, so a teams file that fails to
+// parse must not hide an owner being removed.
+func TestValidateOrg_BrokenTeamsFileStillEnforcesProtectedOwners(t *testing.T) {
+	dir := newOrgConfigDir(t, map[string]string{
+		"teams.yaml":   "teams: [oops\n",
+		"members.yaml": "members:\n  - username: alice\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	require.Error(t, err)
+	assert.Contains(t, out, "invalid YAML")
+	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
+}
+
 func TestValidateOrg_ProtectedOwnerRemovedRejected(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml":   validTeamsYAML,

--- a/feature/github-repo-importer/cmd/validate.go
+++ b/feature/github-repo-importer/cmd/validate.go
@@ -141,8 +141,7 @@ func loadValidationSchema(cmd *cobra.Command, configDir, schemaOverride, fallbac
 }
 
 // compileSchema compiles a JSON schema from schemaPath, or from the built-in
-// marshaller when schemaPath is empty. memURL is the in-memory resource name and
-// only needs to be unique per schema.
+// marshaller when schemaPath is empty.
 func compileSchema(memURL, schemaPath string, builtin func() ([]byte, error)) (*jsonschema.Schema, error) {
 	var doc any
 	var err error
@@ -206,8 +205,7 @@ func resolveOrgSchema(cmd *cobra.Command, configDir string) (string, bool) {
 }
 
 // loadYAMLDocument reads and decodes path into a JSON-compatible value ready for
-// schema validation. The raw bytes are returned too, so a caller that also needs a
-// typed struct can decode from them instead of reading and parsing the file twice.
+// schema validation, returning the raw bytes alongside it.
 func loadYAMLDocument(path string) ([]byte, any, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/feature/github-repo-importer/cmd/validate.go
+++ b/feature/github-repo-importer/cmd/validate.go
@@ -119,42 +119,44 @@ func globRepoConfigs(configDir string) ([]string, error) {
 //  3. fallbackSchema (--fallback-schema flag, e.g. github-terraformer's own .schemas/ file)
 //  4. built-in schema generated from the importer's Go structs
 func loadValidationSchema(cmd *cobra.Command, configDir, schemaOverride, fallbackSchema string) (*jsonschema.Schema, error) {
-	compiler := jsonschema.NewCompiler()
-
 	if schemaOverride == "" {
 		if candidate, ok := resolveOrgSchema(cmd, configDir); ok {
 			schemaOverride = candidate
 		}
 	}
 
-	const schemaURL = "mem://repository-config.schema.json"
-
-	var doc any
-	var err error
+	schemaPath := ""
 	switch {
 	case schemaOverride != "":
 		cmd.Printf("Using org schema override: %s\n", schemaOverride)
-		f, openErr := os.Open(schemaOverride)
-		if openErr != nil {
-			return nil, fmt.Errorf("open schema override %s: %w", schemaOverride, openErr)
-		}
-		defer func() { _ = f.Close() }()
-		if doc, err = jsonschema.UnmarshalJSON(f); err != nil {
-			return nil, fmt.Errorf("parse schema override %s: %w", schemaOverride, err)
-		}
+		schemaPath = schemaOverride
 	case fallbackSchema != "":
 		cmd.Printf("Using base schema: %s\n", fallbackSchema)
-		f, openErr := os.Open(fallbackSchema)
+		schemaPath = fallbackSchema
+	default:
+		cmd.Println("Using built-in schema")
+	}
+
+	return compileSchema("mem://repository-config.schema.json", schemaPath, MarshalRepositoryConfigSchema)
+}
+
+// compileSchema compiles a JSON schema from schemaPath, or from the built-in
+// marshaller when schemaPath is empty. memURL is the in-memory resource name and
+// only needs to be unique per schema.
+func compileSchema(memURL, schemaPath string, builtin func() ([]byte, error)) (*jsonschema.Schema, error) {
+	var doc any
+	var err error
+	if schemaPath != "" {
+		f, openErr := os.Open(schemaPath)
 		if openErr != nil {
-			return nil, fmt.Errorf("open fallback schema %s: %w", fallbackSchema, openErr)
+			return nil, fmt.Errorf("open schema %s: %w", schemaPath, openErr)
 		}
 		defer func() { _ = f.Close() }()
 		if doc, err = jsonschema.UnmarshalJSON(f); err != nil {
-			return nil, fmt.Errorf("parse fallback schema %s: %w", fallbackSchema, err)
+			return nil, fmt.Errorf("parse schema %s: %w", schemaPath, err)
 		}
-	default:
-		cmd.Println("Using built-in schema")
-		raw, marshalErr := MarshalRepositoryConfigSchema()
+	} else {
+		raw, marshalErr := builtin()
 		if marshalErr != nil {
 			return nil, marshalErr
 		}
@@ -163,10 +165,11 @@ func loadValidationSchema(cmd *cobra.Command, configDir, schemaOverride, fallbac
 		}
 	}
 
-	if err := compiler.AddResource(schemaURL, doc); err != nil {
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(memURL, doc); err != nil {
 		return nil, fmt.Errorf("load schema: %w", err)
 	}
-	schema, err := compiler.Compile(schemaURL)
+	schema, err := compiler.Compile(memURL)
 	if err != nil {
 		return nil, fmt.Errorf("compile schema: %w", err)
 	}

--- a/feature/github-repo-importer/cmd/validate.go
+++ b/feature/github-repo-importer/cmd/validate.go
@@ -205,25 +205,40 @@ func resolveOrgSchema(cmd *cobra.Command, configDir string) (string, bool) {
 	return candidate, true
 }
 
-// validateFile parses a single YAML file and validates it against the schema,
-// returning one message per violation, each citing the file and JSON path.
-func validateFile(path string, schema *jsonschema.Schema) []string {
+// loadYAMLDocument reads and decodes path into a JSON-compatible value ready for
+// schema validation. The raw bytes are returned too, so a caller that also needs a
+// typed struct can decode from them instead of reading and parsing the file twice.
+func loadYAMLDocument(path string) ([]byte, any, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return []string{fmt.Sprintf("%s: failed to read file: %v", path, err)}
+		return nil, nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	var raw any
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return []string{fmt.Sprintf("%s: invalid YAML: %v", path, err)}
+		return nil, nil, fmt.Errorf("invalid YAML: %w", err)
 	}
 
 	instance, err := toJSONValue(raw)
 	if err != nil {
+		return nil, nil, err
+	}
+	return data, instance, nil
+}
+
+// validateFile parses a single YAML file and validates it against the schema,
+// returning one message per violation, each citing the file and JSON path.
+func validateFile(path string, schema *jsonschema.Schema) []string {
+	_, instance, err := loadYAMLDocument(path)
+	if err != nil {
 		return []string{fmt.Sprintf("%s: %v", path, err)}
 	}
+	return validateInstance(path, instance, schema)
+}
 
-	err = schema.Validate(instance)
+// validateInstance validates an already-decoded document against the schema.
+func validateInstance(path string, instance any, schema *jsonschema.Schema) []string {
+	err := schema.Validate(instance)
 	if err == nil {
 		return nil
 	}

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -1,6 +1,9 @@
 package github
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type MembersConfig struct {
 	Members []Member `yaml:"members,omitempty"`
@@ -29,27 +32,45 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	var errs []error
 
 	teamSet := make(map[string]struct{}, len(knownTeams))
+	teamsByFold := make(map[string]string, len(knownTeams))
 	for _, t := range knownTeams {
 		teamSet[t] = struct{}{}
+		teamsByFold[strings.ToLower(t)] = t
 	}
 
-	seen := make(map[string]struct{}, len(c.Members))
+	// Logins are compared case-insensitively: GitHub treats them that way, so two
+	// entries differing only in case are one account managed by two resources.
+	seen := make(map[string]string, len(c.Members))
 	for _, member := range c.Members {
-		if _, exists := seen[member.Username]; exists {
+		key := strings.ToLower(member.Username)
+		first, exists := seen[key]
+		switch {
+		case !exists:
+			seen[key] = member.Username
+		case first == member.Username:
 			errs = append(errs, fmt.Errorf("member %q is defined more than once in members.yaml", member.Username))
+		default:
+			errs = append(errs, fmt.Errorf("member %q collides with %q in members.yaml: GitHub logins are case-insensitive, so these are the same account", member.Username, first))
 		}
-		seen[member.Username] = struct{}{}
 
 		memberTeams := make(map[string]struct{}, len(member.Teams))
 		for _, team := range member.Teams {
-			if _, exists := memberTeams[team.Name]; exists {
+			teamKey := strings.ToLower(team.Name)
+			if _, exists := memberTeams[teamKey]; exists {
 				errs = append(errs, fmt.Errorf("member %q lists team %q more than once", member.Username, team.Name))
 			}
-			memberTeams[team.Name] = struct{}{}
+			memberTeams[teamKey] = struct{}{}
 
-			if _, ok := teamSet[team.Name]; !ok {
-				errs = append(errs, fmt.Errorf("member %q references team %q which is not defined in teams.yaml", member.Username, team.Name))
+			// Matched exactly: Terraform resolves a member's team by looking the name
+			// up as a map key, so a reference that differs in case fails at plan time.
+			if _, ok := teamSet[team.Name]; ok {
+				continue
 			}
+			if actual, defined := teamsByFold[teamKey]; defined {
+				errs = append(errs, fmt.Errorf("member %q references team %q but teams.yaml defines it as %q: team references must match exactly", member.Username, team.Name, actual))
+				continue
+			}
+			errs = append(errs, fmt.Errorf("member %q references team %q which is not defined in teams.yaml", member.Username, team.Name))
 		}
 	}
 
@@ -64,11 +85,11 @@ func (c *MembersConfig) ValidateProtectedOwners(protectedOwners []string) []erro
 
 	byUsername := make(map[string]Member, len(c.Members))
 	for _, member := range c.Members {
-		byUsername[member.Username] = member
+		byUsername[strings.ToLower(member.Username)] = member
 	}
 
 	for _, owner := range protectedOwners {
-		member, present := byUsername[owner]
+		member, present := byUsername[strings.ToLower(owner)]
 		if !present {
 			errs = append(errs, fmt.Errorf("protected owner %q is missing from members.yaml: protected identities cannot be removed", owner))
 			continue

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -25,9 +25,7 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 	return append(errs, c.ValidateProtectedOwners(protectedOwners)...)
 }
 
-// ValidateEntries checks the rules that hold within a single members file. Run it
-// per file: these are structural, and evaluating them on a merged set would hide a
-// duplicate that another file happens to override.
+// ValidateEntries checks the rules that hold within a single members file.
 func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	var errs []error
 
@@ -38,8 +36,6 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 		teamsByFold[strings.ToLower(t)] = t
 	}
 
-	// Logins are compared case-insensitively: GitHub treats them that way, so two
-	// entries differing only in case are one account managed by two resources.
 	seen := make(map[string]string, len(c.Members))
 	for _, member := range c.Members {
 		key := strings.ToLower(member.Username)
@@ -61,8 +57,6 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 			}
 			memberTeams[teamKey] = struct{}{}
 
-			// Matched exactly: Terraform resolves a member's team by looking the name
-			// up as a map key, so a reference that differs in case fails at plan time.
 			if _, ok := teamSet[team.Name]; ok {
 				continue
 			}
@@ -77,9 +71,7 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	return errs
 }
 
-// ValidateProtectedOwners checks that every protected owner is present and still an
-// owner. Run it on the effective (merged) member set: an owner may be declared in
-// either the promoted or the staged file.
+// ValidateProtectedOwners checks that every protected owner is present and still an owner.
 func (c *MembersConfig) ValidateProtectedOwners(protectedOwners []string) []error {
 	var errs []error
 

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -18,6 +18,14 @@ type TeamMembership struct {
 }
 
 func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) []error {
+	errs := c.ValidateEntries(knownTeams)
+	return append(errs, c.ValidateProtectedOwners(protectedOwners)...)
+}
+
+// ValidateEntries checks the rules that hold within a single members file. Run it
+// per file: these are structural, and evaluating them on a merged set would hide a
+// duplicate that another file happens to override.
+func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	var errs []error
 
 	teamSet := make(map[string]struct{}, len(knownTeams))
@@ -25,12 +33,12 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 		teamSet[t] = struct{}{}
 	}
 
-	seen := make(map[string]Member, len(c.Members))
+	seen := make(map[string]struct{}, len(c.Members))
 	for _, member := range c.Members {
 		if _, exists := seen[member.Username]; exists {
 			errs = append(errs, fmt.Errorf("member %q is defined more than once in members.yaml", member.Username))
 		}
-		seen[member.Username] = member
+		seen[member.Username] = struct{}{}
 
 		memberTeams := make(map[string]struct{}, len(member.Teams))
 		for _, team := range member.Teams {
@@ -45,8 +53,22 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 		}
 	}
 
+	return errs
+}
+
+// ValidateProtectedOwners checks that every protected owner is present and still an
+// owner. Run it on the effective (merged) member set: an owner may be declared in
+// either the promoted or the staged file.
+func (c *MembersConfig) ValidateProtectedOwners(protectedOwners []string) []error {
+	var errs []error
+
+	byUsername := make(map[string]Member, len(c.Members))
+	for _, member := range c.Members {
+		byUsername[member.Username] = member
+	}
+
 	for _, owner := range protectedOwners {
-		member, present := seen[owner]
+		member, present := byUsername[owner]
 		if !present {
 			errs = append(errs, fmt.Errorf("protected owner %q is missing from members.yaml: protected identities cannot be removed", owner))
 			continue

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -7,13 +7,13 @@ type MembersConfig struct {
 }
 
 type Member struct {
-	Username string           `yaml:"username" jsonschema:"required"`
+	Username string           `yaml:"username" jsonschema:"required,minLength=1"`
 	Role     string           `yaml:"role,omitempty" jsonschema:"enum=owner,enum=member"`
 	Teams    []TeamMembership `yaml:"teams,omitempty"`
 }
 
 type TeamMembership struct {
-	Name string `yaml:"name" jsonschema:"required"`
+	Name string `yaml:"name" jsonschema:"required,minLength=1"`
 	Role string `yaml:"role,omitempty" jsonschema:"enum=member,enum=maintainer"`
 }
 

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -7,7 +7,7 @@ type TeamsConfig struct {
 }
 
 type Team struct {
-	Name          string  `yaml:"name" jsonschema:"required"`
+	Name          string  `yaml:"name" jsonschema:"required,minLength=1"`
 	Slug          *string `yaml:"slug,omitempty" jsonschema:"description=GitHub-generated team slug captured by the importer and used as the Terraform import ID; not meant to be set or edited by hand"`
 	Description   *string `yaml:"description,omitempty"`
 	Visibility    string  `yaml:"visibility,omitempty" jsonschema:"enum=visible,enum=secret"`

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -1,6 +1,9 @@
 package github
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type TeamsConfig struct {
 	Teams []Team `yaml:"teams,omitempty"`
@@ -17,12 +20,20 @@ type Team struct {
 func (c *TeamsConfig) Validate() []error {
 	var errs []error
 
-	seen := make(map[string]struct{}, len(c.Teams))
+	// Compared case-insensitively: GitHub derives a team's slug by lowercasing its
+	// name, so names differing only in case collide on the same team.
+	seen := make(map[string]string, len(c.Teams))
 	for _, team := range c.Teams {
-		if _, exists := seen[team.Name]; exists {
+		key := strings.ToLower(team.Name)
+		first, exists := seen[key]
+		switch {
+		case !exists:
+			seen[key] = team.Name
+		case first == team.Name:
 			errs = append(errs, fmt.Errorf("team %q is defined more than once in teams.yaml", team.Name))
+		default:
+			errs = append(errs, fmt.Errorf("team %q collides with %q in teams.yaml: names differing only in case produce the same GitHub team", team.Name, first))
 		}
-		seen[team.Name] = struct{}{}
 	}
 
 	return errs

--- a/feature/github-repo-importer/pkg/github/teams.go
+++ b/feature/github-repo-importer/pkg/github/teams.go
@@ -20,8 +20,6 @@ type Team struct {
 func (c *TeamsConfig) Validate() []error {
 	var errs []error
 
-	// Compared case-insensitively: GitHub derives a team's slug by lowercasing its
-	// name, so names differing only in case collide on the same team.
 	seen := make(map[string]string, len(c.Teams))
 	for _, team := range c.Teams {
 		key := strings.ToLower(team.Name)


### PR DESCRIPTION
Implements the schema-validation half of GCSS-1391. The separate workspace/state half is a follow-up PR.

## What this does

Validates the organisation `teams.yaml` and `members.yaml` on every PR, **before** Terraform plan, so a bad org config fails fast with a clear message instead of erroring at apply — or worse, planning a member wipe that reads as a clean plan.

Two layers, mirroring how `repos/*.yaml` is already validated:

- **JSON schema** — shape, enums and lengths (`visibility` is `visible|secret`, `role` is `owner|member`, names are non-empty), reusing the existing `validateFile` machinery.
- **Cross-file rules the schema cannot express** — reusing the already-built, already-tested `TeamsConfig.Validate()` / `MembersConfig.Validate()`, which until now were called from nowhere but tests:
  - a member referencing a team not defined in `teams.yaml`
  - duplicate team names / duplicate team memberships
  - a **protected owner** being removed or demoted from owner

## Both config locations are validated

Terraform reads org config from **two** places and `merge()`s them — `organisation/` and the bootstrap importer's staged `importer_tmp_dir/organisation/`. Validation reads and merges both the same way, so:

- staged bootstrap output is schema-checked and cites its real path
- a staged member may reference an already-promoted team without a false positive
- the protected-owner check sees the **merged, effective** config, not either file alone

Without this, the bootstrap import PR — the one that first hands GCSS ownership of the org, and the highest-stakes plan in the feature — would be the single plan receiving no checks at all.

## An absent members.yaml is not a bypass

Terraform reads a missing `members.yaml` as `members: []`, so deleting the file plans the same org-wide member wipe as emptying it. Both are now rejected identically; validation loads an absent file as an empty config rather than skipping the check. `git rm organisation/members.yaml` does not sail through.

## Protected owners and schemas both come from deployment config

`--protected-owners` is threaded from a `protected_owners` workflow input (intended to come from a repo/org Actions variable) and is **never** read from a file inside the config repo — otherwise a PR could edit its own guard away.

For the same reason, and unlike repository config, the org path deliberately does **not** honour a config-repo schema override (`resolveOrgSchema`). Both the rules and the list of who they protect are deployment config, so a pull request cannot weaken what it is validated against.

When no protected owners are configured the run warns rather than passing silently, so an operator can tell an enforced run from an unconfigured one.

## What's included

- **`validate-org` command** — orchestrates both layers over both locations.
- **`compileSchema` + `loadYAMLDocument` / `validateInstance`** — factored out of `validate.go` so the repository, teams and members paths share one schema compiler and one YAML parse, rather than each file being read and parsed once per layer.
- **`validate-org-configs` composite action** — mirrors `validate-repo-configs`.
- **Wiring** — one extra step in the existing `validate` job in `tf-plan.yaml`, reusing its checkouts; `terraform-plan` still `needs: validate`.
- **`minLength: 1`** on team name, member username and team-membership name — `required` only checks presence, so `name: ""` previously produced a resource keyed by the empty string.
- **Tests** — 19 cases, including the deleted-members-file guard, staged-config validation, promoted-over-staged merge precedence, empty names, the no-cascade behaviour when `teams.yaml` fails to parse, and the file-based schema path the composite action actually uses in CI.

## Testing

- `go build` / `go vet` / `go test ./...` pass; schemas regenerate with no drift; workflow and action YAML parse.
- **Verified end-to-end on a test org**, both directions:
  - bootstrap PR with staged files → `ok -- organisation config` (the log line confirms it validated the staged files rather than skipping) → plan `1 to import, 0 to add, 0 to change, 0 to destroy`
  - PR with no members file and `PROTECTED_OWNERS` set → `protected owner "…" is missing from members.yaml`, validate job **failed**, `terraform-plan` **skipped**

## A conscious sequencing call

Org validation is added to the shared `validate` job that `terraform-plan` depends on. Until the workspace split lands, that means a broken `organisation/members.yaml` blocks the plan for a PR touching only `repos/*.yaml` — the shared blast radius #1391 exists to remove, present at the CI layer.

This is deliberate rather than overlooked. While the workspace is shared, the same plan applies org config, so allowing a plan to proceed against config known to be invalid would be the worse failure. Making the step conditional on diff scope would add machinery the workspace split then deletes. The coupling goes away with the split, not before it.

## Rollout / follow-ups

- The config repo needs a `PROTECTED_OWNERS` variable and `protected_owners: ${{ vars.PROTECTED_OWNERS }}` on the tf-plan caller for enforcement to take effect. Note that setting it before the org config is bootstrapped will fail every PR, correctly — it is effectively the "org management adopted" switch.
- The config repo also needs an `import-org` caller workflow; there is currently no way to trigger the bootstrap importer from it.
- **Separate workspace/state**, the other half of #1391, is a follow-up PR — it needs a new HCP workspace and config-repo wiring.
- **Staged repository configs remain unvalidated.** `main.tf` merges `importer_tmp_dir/*.yaml` into the applied set, but `globRepoConfigs` only globs `repos/`. This PR closes that gap for org and leaves it open for repos — same class of bug, pre-existing, and worth its own change since it can make a currently-passing import PR start failing.
