### PR TITLE
schema: allow internal visibility and stop requiring ref_name exclude

### DIFF
--- a/.schemas/repository-config.schema.json
+++ b/.schemas/repository-config.schema.json
@@ -291,7 +291,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "exclude",
         "include"
       ]
     },
@@ -321,7 +320,8 @@
           "type": "string",
           "enum": [
             "public",
-            "private"
+            "private",
+            "internal"
           ]
         },
         "homepage_url": {

--- a/DEVELOPERS_GUIDE.md
+++ b/DEVELOPERS_GUIDE.md
@@ -17,6 +17,7 @@ These are the primary configuration options for each repository.
 - **`visibility`**: *(optional, string)* Defines the visibility of the repository. Possible values:
   - `public`
   - `private`
+  - `internal` *(GitHub Enterprise organizations only)*
 
 - **`homepage_url`**: *(optional, string)* The URL to the repository's homepage or website.
 

--- a/feature/github-repo-importer/cmd/schema_test.go
+++ b/feature/github-repo-importer/cmd/schema_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/gr-oss-devops/github-repo-importer/pkg/github"
 )
 
 func TestBuildTeamsConfigSchema(t *testing.T) {
@@ -79,4 +81,24 @@ func TestBuildRepositoryConfigSchema(t *testing.T) {
 
 	assert.Equal(t, "Repository Configuration", schema.Title)
 	assert.True(t, strings.Contains(string(schema.ID), repositorySchemaOutFile), "schema $id should point at %s, got %s", repositorySchemaOutFile, schema.ID)
+
+	repositoryDef, ok := schema.Definitions["RepositoryWithExpansionConfig"]
+	assert.True(t, ok, "schema should define RepositoryWithExpansionConfig")
+	if ok {
+		visibility, hasVisibility := repositoryDef.Properties.Get("visibility")
+		assert.True(t, hasVisibility, "Repository should have a visibility property")
+		if hasVisibility {
+			assert.Equal(t, []interface{}{
+				github.VisibilityPublic,
+				github.VisibilityPrivate,
+				github.VisibilityInternal,
+			}, visibility.Enum, "visibility must accept every value the importer can emit")
+		}
+	}
+
+	refNameDef, ok := schema.Definitions["RefNameCondition"]
+	assert.True(t, ok, "schema should define RefNameCondition")
+	if ok {
+		assert.Equal(t, []string{"include"}, refNameDef.Required, "an include-only ref_name condition is valid")
+	}
 }

--- a/feature/github-repo-importer/pkg/github/constants.go
+++ b/feature/github-repo-importer/pkg/github/constants.go
@@ -19,8 +19,9 @@ const (
 	RuleCodeScanning              = "code_scanning"
 
 	// Visibility
-	VisibilityPrivate = "private"
-	VisibilityPublic  = "public"
+	VisibilityPrivate  = "private"
+	VisibilityPublic   = "public"
+	VisibilityInternal = "internal"
 
 	TeamVisibilityVisible = "visible"
 	TeamVisibilitySecret  = "secret"

--- a/feature/github-repo-importer/pkg/github/repositories.go
+++ b/feature/github-repo-importer/pkg/github/repositories.go
@@ -4,7 +4,7 @@ type Repository struct {
 	Name                       string                `yaml:"-"`
 	Owner                      string                `yaml:"-"`
 	Description                *string               `yaml:"description,omitempty" jsonschema:"maxLength=350"`
-	Visibility                 string                `yaml:"visibility,omitempty" jsonschema:"enum=public,enum=private"`
+	Visibility                 string                `yaml:"visibility,omitempty" jsonschema:"enum=public,enum=private,enum=internal"`
 	HomepageURL                *string               `yaml:"homepage_url,omitempty"`
 	DefaultBranch              string                `yaml:"default_branch,omitempty" jsonschema:"required"`
 	HasIssues                  *bool                 `yaml:"has_issues,omitempty"`

--- a/feature/github-repo-importer/pkg/github/rulesets.go
+++ b/feature/github-repo-importer/pkg/github/rulesets.go
@@ -79,6 +79,6 @@ type Conditions struct {
 }
 
 type RefNameCondition struct {
-	Exclude []string `yaml:"exclude,omitempty" jsonschema:"minItems=1,required"`
+	Exclude []string `yaml:"exclude,omitempty" jsonschema:"minItems=1"`
 	Include []string `yaml:"include,omitempty" jsonschema:"minItems=1,required"`
 }


### PR DESCRIPTION
Closes G-Research/gr-oss#1425
Closes G-Research/gr-oss#1426

Two independent schema rules reject repository configs that the importer itself
generates, so the validate gate fails on configs that are already applied and running.
Found by running the gate against a real config repository: 9 of 18 files were rejected
on an otherwise empty pull request, and `terraform-plan` never got to run.

Neither is specific to one organization. Any org with a single internal repository, or a
single ruleset that excludes nothing, has every pull request blocked immediately after
upgrading.

## visibility

`Visibility` is assigned verbatim from the API:

```go
Visibility: repo.GetVisibility(),
```

`GetVisibility()` returns `internal` for enterprise-internal repositories, but the enum
listed only `public` and `private`. It matched the older `resolveVisibility(bool)` helper
rather than what the field actually carries. Terraform and the provider accept `internal`,
so affected repositories apply correctly — only the schema disagreed.

```
value must be one of 'public', 'private' at /visibility
```

## ref_name.exclude

`Exclude` was tagged `jsonschema:"...,required"` while its yaml tag is `omitempty`:
optional on the way out, mandatory on the way in. An include-only `ref_name` condition is
valid, is what GitHub returns, and is what the importer writes. `Include` stays required.

```
missing property 'exclude' at /rulesets/0/conditions/ref_name
```

## Changes

| File | Change |
|---|---|
| `pkg/github/repositories.go` | add `enum=internal` to the visibility tag |
| `pkg/github/rulesets.go` | drop `required` from `RefNameCondition.Exclude` |
| `pkg/github/constants.go` | add `VisibilityInternal` alongside the existing constants |
| `DEVELOPERS_GUIDE.md` | document `internal` in the visibility list |
| `cmd/schema_test.go` | assert the visibility enum and the include-only `ref_name` condition |
| `.schemas/repository-config.schema.json` | regenerated |

The last three address review feedback. The new assertions mean neither rule can regress
silently.

## Verification

- `go build`, `go vet`, `go test ./...` pass
- the `.schemas/` diff is exactly the two intended changes, and the CI drift check reports
  no further change
- `importer validate` against a real config repository: all 18 configs pass, where 9
  previously failed
