### PR TITLE
validate-org: do not enforce protected owners before the org is onboarded

### DIFF
--- a/feature/github-repo-importer/cmd/validate-org.go
+++ b/feature/github-repo-importer/cmd/validate-org.go
@@ -44,6 +44,13 @@ Files may be absent. An absent members.yaml is treated as an empty member list,
 matching how Terraform reads it, so protected owners are enforced even when the
 file is deleted outright.
 
+The exception is an organisation that is not under management at all, with both
+teams.yaml and members.yaml absent from either location. Terraform creates no
+membership resources from that state, so there is nothing a plan could remove and
+protected owners are not enforced. Enforcement resumes as soon as either file
+exists, including staged bootstrap output, so the import that first takes ownership
+of the organisation is still checked.
+
 Unlike repository config, the schema is never taken from the config repository:
 both the schema and the protected-owner list are deployment config, so a pull
 request cannot weaken the rules it is validated against.`,
@@ -73,15 +80,20 @@ func runValidateOrg(cmd *cobra.Command, configDir, protectedOwnersCSV, fallbackT
 		filepath.Join(configDir, orgConfigDir, "members.yaml"),
 	)
 
-	protectedOwners := splitCSV(protectedOwnersCSV)
-	if len(protectedOwners) > 0 {
-		cmd.Printf("Enforcing %d protected owner(s): %s\n", len(protectedOwners), strings.Join(protectedOwners, ", "))
-	} else {
-		cmd.PrintErrln("WARNING: no protected owners configured, owner removal and demotion are not enforced")
-	}
+	unmanagedOrg := len(teamsFiles) == 0 && len(membersFiles) == 0
 
-	if len(teamsFiles) == 0 && len(membersFiles) == 0 {
+	protectedOwners := splitCSV(protectedOwnersCSV)
+	switch {
+	case unmanagedOrg:
 		cmd.Println("No organisation teams.yaml or members.yaml found, validating as an empty organisation config")
+		if len(protectedOwners) > 0 {
+			cmd.PrintErrln("WARNING: the organisation is not under management yet, so protected owners are not enforced; they take effect once organisation config exists")
+			protectedOwners = nil
+		}
+	case len(protectedOwners) > 0:
+		cmd.Printf("Enforcing %d protected owner(s): %s\n", len(protectedOwners), strings.Join(protectedOwners, ", "))
+	default:
+		cmd.PrintErrln("WARNING: no protected owners configured, owner removal and demotion are not enforced")
 	}
 
 	var failures []string

--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -302,6 +302,28 @@ func TestValidateOrg_NoFilesAndNoProtectedOwnersPasses(t *testing.T) {
 	assert.Contains(t, out, "ok -- organisation config")
 }
 
+func TestValidateOrg_UnmanagedOrgDoesNotEnforceProtectedOwners(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	assert.NoError(t, err, "an organisation with no config manages no memberships, so nothing can be removed")
+	assert.Contains(t, out, "not under management yet")
+	assert.Contains(t, out, "ok -- organisation config")
+}
+
+func TestValidateOrg_StagedBootstrapEnforcesProtectedOwners(t *testing.T) {
+	dir := newStagedOrgConfigDir(t, map[string]string{
+		"teams.yaml":   validTeamsYAML,
+		"members.yaml": "members:\n  - username: someone-else\n    role: owner\n",
+	})
+
+	out, err := runValidateOrgCmd(t, dir, "gcss-bot")
+
+	require.Error(t, err, "enforcement must resume as soon as staged bootstrap output exists")
+	assert.Contains(t, out, `protected owner "gcss-bot" is missing from members.yaml`)
+}
+
 func TestValidateOrg_DeletedMembersFileStillEnforcesProtectedOwners(t *testing.T) {
 	dir := newOrgConfigDir(t, map[string]string{
 		"teams.yaml": validTeamsYAML,


### PR DESCRIPTION
Closes G-Research/gr-oss#1428

With `protected_owners` configured and no organisation config in the repository yet,
`validate-org` rejects every pull request:

```
No organisation teams.yaml or members.yaml found, validating as an empty organisation config
...
protected owner "<login>" is missing from members.yaml: protected identities cannot be removed
```

Nothing is being removed — the organisation has never been onboarded.

## Why it blocks adoption

The guard is meant to be set before the bootstrap import, so that the import pull request
itself is checked. The bootstrap pull request does pass, because its staged `members.yaml`
lists the protected owners. But between setting the variable and merging that import,
**every unrelated pull request is rejected** — repository config changes have nothing to do
with organisation membership, yet they cannot get past the gate.

## Cause

Treating an absent `members.yaml` as an empty member list is right for an organisation
already under management, where an empty list plans a member wipe. Before adoption it is
not: with no organisation config anywhere, Terraform creates no `github_membership`
resources, so there is no state a plan could remove.

`runValidateOrg` already computed and printed the distinguishing condition without acting
on it.

## Change

| State | Before | After |
|---|---|---|
| `teams.yaml` and `members.yaml` both absent | rejected | skipped, with a warning |
| `members.yaml` absent, `teams.yaml` present | rejected | rejected — a deleted file |
| `members.yaml` present, owner omitted | rejected | rejected |

Enforcement resumes as soon as either file exists, including staged bootstrap output, so
the highest-stakes plan is still checked. The command's help text stated the rule without
this exception and has been updated.

## Tests

Two added, and the existing coverage is what proves the guard was not weakened:

- `UnmanagedOrgDoesNotEnforceProtectedOwners` — no config, owners set, passes with a warning
- `StagedBootstrapEnforcesProtectedOwners` — staged output omitting an owner is still rejected
- `DeletedMembersFileStillEnforcesProtectedOwners` and `EmptyMembersListEnforcesProtectedOwners`
  continue to pass unchanged

## Verification

- `go build`, `go vet`, `go test ./...` pass
- run against a real config repository with no organisation config: fails before, passes
  after; adding a `teams.yaml` makes it fail again, as intended
