### PR TITLE
compare: treat an empty value and an absent key as equal

### DIFF
--- a/feature/github-repo-importer/pkg/compare/compare.go
+++ b/feature/github-repo-importer/pkg/compare/compare.go
@@ -137,11 +137,6 @@ func removeKey(node *yaml.Node, target string) {
 	}
 }
 
-// removeEmptyValues drops mapping entries whose value is an empty string or null, so a
-// config that writes `homepage_url: ""` and one that omits the key entirely hash the same.
-// Only scalars qualify: false and 0 are meaningful values and are kept. Containers left
-// empty by this pass are also kept, since collapsing them asserts an equivalence this does
-// not need.
 func removeEmptyValues(node *yaml.Node) {
 	switch node.Kind {
 	case yaml.MappingNode:

--- a/feature/github-repo-importer/pkg/compare/compare.go
+++ b/feature/github-repo-importer/pkg/compare/compare.go
@@ -102,6 +102,7 @@ func hashNormalizedYamlFile(path string) (string, error) {
 		removeKey(root, "id")
 		removeKey(root, "branch_policy_ids")
 		removeKey(root, "tag_policy_ids")
+		removeEmptyValues(root)
 		sortMappingNode(root)
 	}
 
@@ -134,6 +135,39 @@ func removeKey(node *yaml.Node, target string) {
 			removeKey(elem, target)
 		}
 	}
+}
+
+// removeEmptyValues drops mapping entries whose value is an empty string or null, so a
+// config that writes `homepage_url: ""` and one that omits the key entirely hash the same.
+// Only scalars qualify: false and 0 are meaningful values and are kept. Containers left
+// empty by this pass are also kept, since collapsing them asserts an equivalence this does
+// not need.
+func removeEmptyValues(node *yaml.Node) {
+	switch node.Kind {
+	case yaml.MappingNode:
+		newContent := make([]*yaml.Node, 0, len(node.Content))
+		for i := 0; i < len(node.Content); i += 2 {
+			k := node.Content[i]
+			v := node.Content[i+1]
+			if isEmptyScalar(v) {
+				continue
+			}
+			removeEmptyValues(v)
+			newContent = append(newContent, k, v)
+		}
+		node.Content = newContent
+	case yaml.SequenceNode:
+		for _, elem := range node.Content {
+			removeEmptyValues(elem)
+		}
+	}
+}
+
+func isEmptyScalar(node *yaml.Node) bool {
+	if node.Kind != yaml.ScalarNode {
+		return false
+	}
+	return node.Tag == "!!null" || (node.Tag == "!!str" && node.Value == "")
 }
 
 func sortMappingNode(node *yaml.Node) {

--- a/feature/github-repo-importer/pkg/compare/compare_test.go
+++ b/feature/github-repo-importer/pkg/compare/compare_test.go
@@ -38,7 +38,7 @@ func TestHashingYamlFiles(t *testing.T) {
 			wantEqual:      true,
 		},
 		{
-			name:           "empty and null values are equivalent to the key being absent, while false is kept",
+			name:           "empty and null values are equivalent to the key being absent",
 			pathOfImported: "testdata/imported/imported5.yaml",
 			pathOfFresh:    "testdata/existing/existing5.yaml",
 			wantEqual:      true,
@@ -47,6 +47,12 @@ func TestHashingYamlFiles(t *testing.T) {
 			name:           "a real difference is still detected alongside an empty value",
 			pathOfImported: "testdata/imported/imported6.yaml",
 			pathOfFresh:    "testdata/existing/existing6.yaml",
+			wantEqual:      false,
+		},
+		{
+			name:           "a false value on one side only is a difference, not an empty value",
+			pathOfImported: "testdata/imported/imported7.yaml",
+			pathOfFresh:    "testdata/existing/existing7.yaml",
 			wantEqual:      false,
 		},
 	}

--- a/feature/github-repo-importer/pkg/compare/compare_test.go
+++ b/feature/github-repo-importer/pkg/compare/compare_test.go
@@ -37,6 +37,18 @@ func TestHashingYamlFiles(t *testing.T) {
 			pathOfFresh:    "testdata/existing/existing4.yaml",
 			wantEqual:      true,
 		},
+		{
+			name:           "empty and null values are equivalent to the key being absent, while false is kept",
+			pathOfImported: "testdata/imported/imported5.yaml",
+			pathOfFresh:    "testdata/existing/existing5.yaml",
+			wantEqual:      true,
+		},
+		{
+			name:           "a real difference is still detected alongside an empty value",
+			pathOfImported: "testdata/imported/imported6.yaml",
+			pathOfFresh:    "testdata/existing/existing6.yaml",
+			wantEqual:      false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/feature/github-repo-importer/pkg/compare/testdata/existing/existing5.yaml
+++ b/feature/github-repo-importer/pkg/compare/testdata/existing/existing5.yaml
@@ -1,0 +1,21 @@
+description: ""
+homepage_url: ""
+visibility: public
+default_branch: main
+has_issues: true
+has_downloads: false
+allow_auto_merge: false
+archived: false
+license_template:
+rulesets:
+  - enforcement: active
+    name: test
+    rules:
+      deletion: true
+      non_fast_forward: true
+    target: branch
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+vulnerability_alerts_enabled: true

--- a/feature/github-repo-importer/pkg/compare/testdata/existing/existing6.yaml
+++ b/feature/github-repo-importer/pkg/compare/testdata/existing/existing6.yaml
@@ -1,0 +1,8 @@
+description: Managed by Terraform
+homepage_url: ""
+visibility: public
+default_branch: main
+has_issues: true
+has_downloads: false
+archived: false
+vulnerability_alerts_enabled: true

--- a/feature/github-repo-importer/pkg/compare/testdata/existing/existing7.yaml
+++ b/feature/github-repo-importer/pkg/compare/testdata/existing/existing7.yaml
@@ -1,0 +1,6 @@
+visibility: public
+default_branch: main
+has_issues: true
+has_downloads: false
+archived: false
+vulnerability_alerts_enabled: true

--- a/feature/github-repo-importer/pkg/compare/testdata/imported/imported5.yaml
+++ b/feature/github-repo-importer/pkg/compare/testdata/imported/imported5.yaml
@@ -1,0 +1,18 @@
+visibility: public
+default_branch: main
+has_issues: true
+has_downloads: false
+allow_auto_merge: false
+archived: false
+rulesets:
+  - enforcement: active
+    name: test
+    rules:
+      deletion: true
+      non_fast_forward: true
+    target: branch
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+vulnerability_alerts_enabled: true

--- a/feature/github-repo-importer/pkg/compare/testdata/imported/imported6.yaml
+++ b/feature/github-repo-importer/pkg/compare/testdata/imported/imported6.yaml
@@ -1,0 +1,7 @@
+description: Edited by hand outside the tool
+visibility: public
+default_branch: main
+has_issues: true
+has_downloads: false
+archived: false
+vulnerability_alerts_enabled: true

--- a/feature/github-repo-importer/pkg/compare/testdata/imported/imported7.yaml
+++ b/feature/github-repo-importer/pkg/compare/testdata/imported/imported7.yaml
@@ -1,0 +1,5 @@
+visibility: public
+default_branch: main
+has_issues: true
+archived: false
+vulnerability_alerts_enabled: true


### PR DESCRIPTION
Closes G-Research/gr-oss#1430

The importer stopped writing `description` and `homepage_url` when the value is empty —
`nilIfEmpty()`, introduced in f6454cb. Every existing config therefore differs from a fresh
import of the same **unchanged** repository, and `compare`, whose only job is answering
whether something changed, started answering wrongly.

Measured against a real config repository during release testing:

| Where | Noise |
|---|---|
| Committed configs carrying `homepage_url: ""` | 10 of 19 |
| Drift check pull request | 7 of 14 entries |
| Bulk import pull request | 8 of 12 entries |

Three features filter through `compare` and all three degraded. `import` and `bulk-import`
stopped dropping unchanged repositories, which is the exact symptom #51 set out to remove.
`drift-check` began reporting repositories that had not drifted — awkwardly, since the change
arrived in the same pull request that built drift-check on top of `compare`.

## Approach

Normalise in `compare` rather than revert the importer.

`nilIfEmpty` produces cleaner generated config and is worth keeping. More importantly this
covers the whole class: a future serialization change that moves a field between empty and
absent stops mattering, rather than this one instance being patched.

`hashNormalizedYamlFile` already establishes the pattern — it drops `id`,
`branch_policy_ids` and `tag_policy_ids` before hashing, then sorts keys. This is one more
step alongside those, reusing the same recursive shape.

## Deliberately narrow

- **Only scalars.** `false` and `0` are meaningful values and are kept; the YAML tag
  distinguishes them from an empty string.
- **Containers left empty are kept.** If stripping empties leaves `reviewers: {}` it stays.
  Collapsing empty maps and lists asserts an equivalence this does not need, and
  over-normalising would hide real differences.

Only empty is ever collapsed against absent. A config saying `description: "old"` against a
fresh import that omits it still compares as different.

## Tests

The existing table had four cases and **all of them asserted equality**, so an over-aggressive
normaliser would have passed every one silently. Two added:

- empty and null equivalent to absent, **with `has_downloads: false` present** — dropping
  falsey values rather than empty ones is the obvious way to get this wrong
- a genuine difference alongside an empty value, asserting **inequality**

Confirmed the first fails without the change and passes with it, so it actually guards the
regression.

## Verification

`go build`, `go vet`, `go test ./pkg/compare/...` all pass.

Against the real config repository, importing six unchanged repositories:

| | identical |
|---|---|
| before | 1 of 6 |
| after | 6 of 6 |

Then editing two of the fresh files — a description, and `has_issues` from `true` to `false` —
returns exactly those two as different. The boolean case matters: it confirms falsey values
survive normalisation.
