### PR TITLE
decommission: resolve the workspace Terraform version and fail clearly without a token

### DIFF
--- a/.github/actions/resolve-tf-version/action.yaml
+++ b/.github/actions/resolve-tf-version/action.yaml
@@ -50,6 +50,10 @@ runs:
           exit 1
         fi
 
+        # Constraints are conventionally written with a space, as in "~> 1.14.0", so match
+        # against a spaceless form rather than requiring one particular spelling.
+        required=${required// /}
+
         # setup-terraform takes an exact version or a constraint starting with "<". A
         # workspace may store either an exact version or a pessimistic constraint, so
         # translate the latter to its upper bound. Never fall back to the latest release:

--- a/.github/actions/resolve-tf-version/action.yaml
+++ b/.github/actions/resolve-tf-version/action.yaml
@@ -1,0 +1,74 @@
+name: "Resolve the workspace Terraform version"
+description: "Reads the Terraform version a HCP workspace requires, for jobs that run state operations locally. Plan and apply execute remotely and do not need this."
+inputs:
+  tfc-token:
+    description: "HCP token for authentication"
+    required: true
+  tfc-organization:
+    description: "HCP cloud organization"
+    required: true
+  tfc-workspace:
+    description: "HCP cloud workspace name"
+    required: true
+outputs:
+  terraform-version:
+    description: "Version to install, in a form setup-terraform accepts"
+    value: ${{ steps.resolve.outputs.terraform-version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve the workspace Terraform version
+      id: resolve
+      shell: bash
+      env:
+        TFC_TOKEN: ${{ inputs.tfc-token }}
+        TFC_ORG: ${{ inputs.tfc-organization }}
+        TFC_WORKSPACE: ${{ inputs.tfc-workspace }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${TFC_TOKEN}" ]; then
+          echo "::error::No HCP token available. This workflow runs state operations outside a deployment environment, so the token must be a repository-level secret. An environment-scoped secret is not readable here."
+          exit 1
+        fi
+        if [ -z "${TFC_WORKSPACE}" ]; then
+          echo "::error::No workspace name available. WORKSPACE must be a repository-level Actions variable for the same reason as the token."
+          exit 1
+        fi
+
+        response=$(curl -sS --fail-with-body \
+          -H "Authorization: Bearer ${TFC_TOKEN}" \
+          -H "Content-Type: application/vnd.api+json" \
+          "https://app.terraform.io/api/v2/organizations/${TFC_ORG}/workspaces/${TFC_WORKSPACE}") || {
+          echo "::error::Could not read workspace '${TFC_WORKSPACE}' in organization '${TFC_ORG}'. Check the token is valid and has access to it."
+          exit 1
+        }
+
+        required=$(printf '%s' "$response" | jq -r '.data.attributes["terraform-version"] // empty')
+        if [ -z "$required" ]; then
+          echo "::error::Workspace '${TFC_WORKSPACE}' reported no Terraform version."
+          exit 1
+        fi
+
+        # setup-terraform takes an exact version or a constraint starting with "<". A
+        # workspace may store either an exact version or a pessimistic constraint, so
+        # translate the latter to its upper bound. Never fall back to the latest release:
+        # installing a version the workspace rejects is the failure this exists to prevent.
+        case "$required" in
+          [0-9]*.[0-9]*.[0-9]*)
+            resolved="$required"
+            ;;
+          "~>"[0-9]*.[0-9]*.[0-9]*)
+            base=${required#"~>"}
+            major=${base%%.*}
+            minor=$(printf '%s' "$base" | cut -d. -f2)
+            resolved="<${major}.$((minor + 1)).0"
+            ;;
+          *)
+            echo "::error::Workspace '${TFC_WORKSPACE}' requires '${required}', which this action cannot translate into a version setup-terraform accepts. Set the workspace to an exact version, or extend this action to handle it."
+            exit 1
+            ;;
+        esac
+
+        echo "Workspace requires '${required}', installing '${resolved}'"
+        echo "terraform-version=${resolved}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/decommission.yaml
+++ b/.github/workflows/decommission.yaml
@@ -10,8 +10,10 @@ name: Decommission repository
 #
 # Run this while repos/<repo>.yaml is still present, then delete the YAML afterward via
 # the normal config PR — the resources are already out of state, so that apply is a no-op.
-# WORKSPACE must be a repository-level Actions variable: the discover job and the
-# concurrency group run outside the environment and can't read environment-scoped vars.
+# WORKSPACE and the HCP token must both be repository-level: the discover job and the
+# concurrency group run outside the environment and can't read environment-scoped values.
+# Unlike plan and apply, which execute remotely, state operations run locally and need a
+# CLI version the workspace accepts, so both jobs resolve it before installing Terraform.
 
 on:
   workflow_call:
@@ -86,9 +88,18 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve the workspace Terraform version
+        id: tfversion
+        uses: ./.github/actions/resolve-tf-version
+        with:
+          tfc-token: ${{ secrets.tfc_token }}
+          tfc-organization: ${{ inputs.tfc_org }}
+          tfc-workspace: ${{ vars.WORKSPACE }}
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
+          terraform_version: ${{ steps.tfversion.outputs.terraform-version }}
           cli_config_credentials_token: ${{ secrets.tfc_token }}
 
       - name: Link backend file
@@ -168,9 +179,18 @@ jobs:
           ref: ${{ inputs.gcss_ref }}
           persist-credentials: false
 
+      - name: Resolve the workspace Terraform version
+        id: tfversion
+        uses: ./.github/actions/resolve-tf-version
+        with:
+          tfc-token: ${{ secrets.tfc_token }}
+          tfc-organization: ${{ inputs.tfc_org }}
+          tfc-workspace: ${{ vars.WORKSPACE }}
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
+          terraform_version: ${{ steps.tfversion.outputs.terraform-version }}
           cli_config_credentials_token: ${{ secrets.tfc_token }}
 
       - name: Link backend file

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -57,6 +57,39 @@ Caller also passes `reviewers` (comma-separated users or `org/team` slugs) to re
 - **Deleted / archived managed repos**: these can't be represented as a config change, so they won't appear in the drift PR. `terraform plan` still flags them and the `Inspect drift` step emits a warning, but resolving them (remove config or recreate the repo) is manual.
 - GitHub disables scheduled workflows after long repo inactivity — a disabled `drift-check` means no detection.
 
+### 🗑 `Decommission` Workflow
+
+Forgets a repository that has **left the organization** — transferred out or deleted — from Terraform state **without destroying it**. Deleting its config alone would make Terraform plan a destroy of a repository the organization no longer owns, and because state is shared, one orphaned repository blocks plans for every other one.
+
+- **Trigger**: Manual (`workflow_dispatch`) from the config repo, with the repository name.
+- **Behavior**:
+    1. `discover` lists every state address the repository owns — `module.repository["<repo>"]` plus root-level resources matched by their `repository` attribute, so hashed ruleset keys and composite-keyed environment resources are never missed.
+    2. `decommission` waits for approval, then runs `terraform state rm` on that list.
+    3. A final step re-reads state and fails if anything still references the repository.
+
+> [!IMPORTANT]
+> Run this **while `repos/<repo>.yaml` is still present**, then delete the config afterwards through a normal pull request. `discover` refuses to run without it. Because the resources are already out of state by then, that later apply is a no-op.
+
+#### Consumer setup requirements
+
+| Name | Type | Scope | Purpose |
+|---|---|---|---|
+| `WORKSPACE` | variable | **repository** | Terraform Cloud workspace |
+| `TFC_TOKEN` | secret | **repository** | Terraform Cloud API token, needing write access to the workspace — `state rm` modifies state |
+| `tfc_token` | secret | `decommission` environment | The same token, for the job that runs behind the approval gate |
+
+> [!WARNING]
+> Both must be **repository-level**, unlike every other workflow here. The `discover` job and the concurrency group run outside any deployment environment and cannot read environment-scoped values. A token available only to the `decommission` environment leaves `discover` unable to reach the workspace at all.
+
+The `decommission` environment **must** have required reviewers. That approval is the only gate before state is modified.
+
+#### Notes / limitations
+
+- **State only.** The repository on GitHub is never touched — this removes Terraform's record of it, nothing more.
+- **Terraform version.** Both jobs read the version the workspace requires and install that. `plan` and `apply` are unaffected by version drift because they execute remotely, but `state rm` runs locally against remote state and is refused if the CLI does not satisfy the workspace constraint.
+- **Concurrency** is per workspace with `cancel-in-progress: false`, so runs queue rather than interrupt a state operation.
+- The address list is computed in `discover`, before the approval wait. If state changes while the run waits, the final verification step fails and the workflow must be re-run so the list is rediscovered.
+
 ## 📥 Importing Existing Repositories
 
 To import an **existing GitHub repository** into Terraform:


### PR DESCRIPTION
Closes G-Research/gr-oss#1436
Closes G-Research/gr-oss#1437

The `decommission` workflow could not run at all. Two independent defects, both in the path
before any state is touched, and the feature is unusable until both land — hence one pull
request.

## The token

`discover` declares no `environment:`, so it cannot read an environment-scoped secret, which
is where the installation guide puts the HCP token. The caller's `secrets.TFC_TOKEN` is also
evaluated outside any environment, so it resolves to an empty string and `terraform init`
fails with:

```
Error: Required token could not be found
```

— which points nowhere near the cause.

The workflow already carried exactly this reasoning for a different input:

```
# WORKSPACE must be a repository-level Actions variable: the discover job and the
# concurrency group run outside the environment and can't read environment-scoped vars.
```

The same constraint applies to the token and was not carried across.

## The CLI version

Both jobs installed the latest Terraform. `plan` and `apply` are unaffected because they
execute remotely, but `state rm` runs **locally** against remote state and is refused unless
the CLI satisfies the workspace constraint:

```
The local Terraform version (1.15.8) does not meet the version requirements
for remote workspace <org>/<workspace> (~>1.14.0).
```

This one is time-dependent. It worked when the feature was written and broke on its own once a
newer Terraform shipped — no change in either repository was needed. Every consumer inherits
it as soon as their workspace constraint falls behind, and it surfaces only when someone
actually needs to decommission, which is when an orphaned repository is already breaking plans
for everything else.

## Approach

One composite action, `resolve-tf-version`, covers both. It needs the same three values either
way, and both defects want to fail early and clearly:

- refuses to continue without a token, naming the repository-level requirement
- reads the version the workspace requires and hands it to `setup-terraform`

It **never falls back to the latest release** — installing a version the workspace rejects is
the failure it exists to prevent.

This mirrors `link-backend`, the existing precedent for extracting the few lines both jobs
need.

### Version shapes

A workspace may report an exact version or a pessimistic constraint, and `setup-terraform`
accepts exact versions and `<`-style constraints but not `~>`. Verified across the shapes:

Constraints are conventionally written with a space, so spacing is normalised before
matching rather than one spelling being privileged.

| Workspace reports | Installed |
|---|---|
| `1.14.3` | `1.14.3` |
| `~> 1.14.0` or `~>1.14.0` | `<1.15.0` |
| `~> 1.9.0` | `<1.10.0` |
| `~> 1.14`, `>= 1.14.0`, `latest`, empty | rejected with an actionable error |

Rejecting the two-component `~>1.14` is deliberate: it means `>=1.14, <2.0`, not the same
thing, and guessing there would install a version the workspace might refuse.

### Applied to both jobs

The version failure was observed only in the mutating job — with a mismatched CLI, `discover`
completed fine, since `terraform show -json` and `terraform state list` tolerate it, and only
`state rm` refused.

Both jobs still resolve it. `discover` reads state, a future version could break that too, and
two jobs installing different CLIs is a trap for the next reader.

`graformer` is deliberately untouched, and the action's description says why: plan and apply
run remotely, so the local CLI is only a client there.

## Documentation

`docs/workflows.md` covers `Import` and `Drift Check` and never covered `Decommission`. The
setup requirements are load-bearing — they are half of the token fix — so the new section
states them explicitly, including that the token and `WORKSPACE` must both be
repository-level, unlike every other workflow here.

It also settles the operating order. The original description of the feature says to delete the
config first and then run the workflow; the code refuses to run without it, and testing
confirmed the code:

```
##[error]no config found for '<repo>' under repos/ or importer_tmp_dir/
        — run decommission while the config is still present, then delete the YAML
```

## Verification

Both defects were reproduced against a real organisation during release testing, and the same
path re-verifies the fix. Still to run once this is on a testable ref:

- the two guard cases keep rejecting before Terraform starts
- with the token only in environments, `discover` fails on the new guard with an actionable
  message rather than on `terraform init`
- with the token at repository level, a full run completes **without a pinned version** —
  addresses enumerated including composite-keyed environment resources, approval gate holding,
  `state rm` succeeding, the repository on GitHub untouched, and deleting the config afterwards
  planning no changes

The last group was confirmed manually during testing with both workarounds in place; this run
is what shows the workarounds are no longer needed.

