### PR TITLE
graformer: name organisation resources in the plan summary

### DIFF
--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -96,8 +96,6 @@ runs:
               recreate: []
           };
           
-          // Callers pass change.before for updates, which is fine for stable identity fields
-          // but wrong for anything that changes. Read both sides and show the transition.
           function renderField(resourceChange, field){
             const from = resourceChange.change.before && resourceChange.change.before[field];
             const to = resourceChange.change.after && resourceChange.change.after[field];
@@ -133,9 +131,6 @@ runs:
             }else if(resourceChange.type === 'github_membership'){
               return `${resourceChange.type} :: ${renderField(resourceChange, 'username')} (${renderField(resourceChange, 'role')})`;
             }else if(resourceChange.type === 'github_team_membership'){
-              // The address key is already "<username>/<team>"; the team is not in teamMap,
-              // which only covers data.github_team lookups. Anchored on the resource type so a
-              // module key can never be matched instead.
               const match = resourceChange.address.match(/github_team_membership\.[^.[]+\["([^"]+)"\]$/);
               const membership = match ? match[1] : renderField(resourceChange, 'username');
               return `${resourceChange.type} :: ${membership} (${renderField(resourceChange, 'role')})`;

--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -96,6 +96,17 @@ runs:
               recreate: []
           };
           
+          // Callers pass change.before for updates, which is fine for stable identity fields
+          // but wrong for anything that changes. Read both sides and show the transition.
+          function renderField(resourceChange, field){
+            const from = resourceChange.change.before && resourceChange.change.before[field];
+            const to = resourceChange.change.after && resourceChange.change.after[field];
+            if (from && to && from !== to) {
+              return `${from} -> ${to}`;
+            }
+            return to || from;
+          }
+
           function getResourceNameFromChange(resourceChange, actualChange){
             if(resourceChange.type === 'github_repository'){
               return `${resourceChange.type} :: ${actualChange.name}`
@@ -118,13 +129,16 @@ runs:
             }else if(resourceChange.type === 'github_repository_custom_property'){
               return `${resourceChange.type} :: ${actualChange.repository}/${actualChange.property_name}`;
             }else if(resourceChange.type === 'github_team'){
-              return `${resourceChange.type} :: ${actualChange.name}`;
+              return `${resourceChange.type} :: ${renderField(resourceChange, 'name')}`;
             }else if(resourceChange.type === 'github_membership'){
-              return `${resourceChange.type} :: ${actualChange.username} (${actualChange.role})`;
+              return `${resourceChange.type} :: ${renderField(resourceChange, 'username')} (${renderField(resourceChange, 'role')})`;
             }else if(resourceChange.type === 'github_team_membership'){
-              const match = resourceChange.address.match(/\["([^"]+)"\]/);
-              const membership = match ? match[1] : actualChange.username;
-              return `${resourceChange.type} :: ${membership} (${actualChange.role})`;
+              // The address key is already "<username>/<team>"; the team is not in teamMap,
+              // which only covers data.github_team lookups. Anchored on the resource type so a
+              // module key can never be matched instead.
+              const match = resourceChange.address.match(/github_team_membership\.[^.[]+\["([^"]+)"\]$/);
+              const membership = match ? match[1] : renderField(resourceChange, 'username');
+              return `${resourceChange.type} :: ${membership} (${renderField(resourceChange, 'role')})`;
             } else {
                 return `unknown type ${resourceChange.type}. resource address: ${resourceChange.address}`
             }

--- a/.github/actions/graformer/action.yaml
+++ b/.github/actions/graformer/action.yaml
@@ -117,6 +117,14 @@ runs:
               return `${resourceChange.type} :: ${actualChange.repository}/${actualChange.environment} (${pattern})`;
             }else if(resourceChange.type === 'github_repository_custom_property'){
               return `${resourceChange.type} :: ${actualChange.repository}/${actualChange.property_name}`;
+            }else if(resourceChange.type === 'github_team'){
+              return `${resourceChange.type} :: ${actualChange.name}`;
+            }else if(resourceChange.type === 'github_membership'){
+              return `${resourceChange.type} :: ${actualChange.username} (${actualChange.role})`;
+            }else if(resourceChange.type === 'github_team_membership'){
+              const match = resourceChange.address.match(/\["([^"]+)"\]/);
+              const membership = match ? match[1] : actualChange.username;
+              return `${resourceChange.type} :: ${membership} (${actualChange.role})`;
             } else {
                 return `unknown type ${resourceChange.type}. resource address: ${resourceChange.address}`
             }


### PR DESCRIPTION
Closes G-Research/gr-oss#1433

The plan summary formatter knew nine repository-level resource types and none of the three
the organisation feature introduced, so every team, membership and team membership fell
through to the unknown-type branch:

```
unknown type github_membership. resource address: github_membership.member["<user>"]
unknown type github_team. resource address: github_team.team["<team>"]
unknown type github_team_membership. resource address: github_team_membership.membership["<user>/<team>"]
```

After:

```
github_membership :: <user> (admin)
github_team :: <team>
github_team_membership :: <user>/<team> (maintainer)
```

## Why it matters

This is the output a reviewer reads when approving a change to **who belongs to the
organisation**. The bootstrap import rendered entirely as unknown-type lines, and so does the
case that matters more: a plan **removing** a person shows an address rather than a statement
of who is being removed.

Everything else in the summary was given readable formatting, including the deployment policy
types added most recently. These three were missed.

## Two decisions worth a look

**The role is included for `github_membership`.** Promotion and demotion between `admin` and
`member` are otherwise invisible in the summary — the line would be identical either way. Since
the role is a value rather than an identity, both sides of the change are read and a change is
rendered as a transition:

```
github_membership :: <user> (member -> admin)
github_team :: <old-name> -> <new-name>
```

Callers pass `change.before` for updates, which is harmless for the stable identity fields
every other type renders, but would have shown the role being replaced rather than the one
being applied.

**Team membership takes its name from the resource address**, not `teamMap`. `teamMap` is
built from `planJson.data`, so it covers only `data.github_team` lookups; organisation teams
are resources and are absent from it, which would render `undefined`. The address already
carries `<username>/<team>` in exactly the form wanted. The pattern is anchored on the resource
type, the way the branch protection one already is — unanchored it would take the first
bracketed key, which is correct while these are root-level but would silently return a module
key if they ever moved, without the fallback firing. There is a comment explaining the choice
so it does not get "corrected" to `teamMap` later.

## Verification

The function was extracted from the action and exercised against the real address shapes
observed during release testing:

| Input | Output |
|---|---|
| `github_team.team["<team>"]` | `github_team :: <team>` |
| `github_membership.member["<user>"]`, role `admin` | `github_membership :: <user> (admin)` |
| same, role `member` | `github_membership :: <user> (member)` |
| `github_team_membership.membership["<user>/<team>"]` | `github_team_membership :: <user>/<team> (maintainer)` |
| an existing type | unchanged |
| a genuinely unknown type | still falls through as before |

No other branch is touched.

