### PR TITLE
validate-org: reject a plain member team role for an organisation owner

### DIFF
--- a/feature/github-repo-importer/cmd/validate-org_test.go
+++ b/feature/github-repo-importer/cmd/validate-org_test.go
@@ -369,7 +369,7 @@ func TestValidateOrg_StagedMembersResolveAgainstPromotedTeams(t *testing.T) {
 	stagedDir := filepath.Join(dir, "importer_tmp_dir", "organisation")
 	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(stagedDir, "members.yaml"),
-		[]byte("members:\n  - username: alice\n    role: owner\n    teams:\n      - name: platform\n"), 0o644))
+		[]byte("members:\n  - username: alice\n    role: owner\n    teams:\n      - name: platform\n        role: maintainer\n"), 0o644))
 
 	out, err := runValidateOrgCmd(t, dir, "alice")
 

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -25,6 +25,7 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 	return append(errs, c.ValidateProtectedOwners(protectedOwners)...)
 }
 
+// ValidateEntries checks the rules that hold within a single members file.
 func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	var errs []error
 
@@ -78,7 +79,6 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	return errs
 }
 
-// effectiveTeamRole mirrors the Terraform default, where an omitted role is a plain member.
 func effectiveTeamRole(role string) string {
 	if role == "" {
 		return TeamRoleMember

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -25,7 +25,6 @@ func (c *MembersConfig) Validate(knownTeams []string, protectedOwners []string) 
 	return append(errs, c.ValidateProtectedOwners(protectedOwners)...)
 }
 
-// ValidateEntries checks the rules that hold within a single members file.
 func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	var errs []error
 

--- a/feature/github-repo-importer/pkg/github/members.go
+++ b/feature/github-repo-importer/pkg/github/members.go
@@ -57,6 +57,14 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 			}
 			memberTeams[teamKey] = struct{}{}
 
+			if member.Role == MemberRoleOwner && effectiveTeamRole(team.Role) == TeamRoleMember {
+				if team.Role == "" {
+					errs = append(errs, fmt.Errorf("member %q is an organisation owner, so team %q needs role %q: the role defaults to %q when omitted, and GitHub reports owners as maintainers of every team they belong to, so the plan would keep proposing this change without it ever taking effect", member.Username, team.Name, TeamRoleMaintainer, TeamRoleMember))
+				} else {
+					errs = append(errs, fmt.Errorf("member %q is an organisation owner, so team %q cannot use role %q: GitHub reports owners as maintainers of every team they belong to, so the plan would keep proposing this change without it ever taking effect", member.Username, team.Name, TeamRoleMember))
+				}
+			}
+
 			if _, ok := teamSet[team.Name]; ok {
 				continue
 			}
@@ -69,6 +77,14 @@ func (c *MembersConfig) ValidateEntries(knownTeams []string) []error {
 	}
 
 	return errs
+}
+
+// effectiveTeamRole mirrors the Terraform default, where an omitted role is a plain member.
+func effectiveTeamRole(role string) string {
+	if role == "" {
+		return TeamRoleMember
+	}
+	return role
 }
 
 // ValidateProtectedOwners checks that every protected owner is present and still an owner.

--- a/feature/github-repo-importer/pkg/github/members_test.go
+++ b/feature/github-repo-importer/pkg/github/members_test.go
@@ -19,13 +19,44 @@ func TestMembersConfigValidate(t *testing.T) {
 			name: "valid config with team member and maintainer roles",
 			config: MembersConfig{
 				Members: []Member{
-					{Username: "alice", Role: MemberRoleOwner, Teams: []TeamMembership{{Name: "platform"}}},
+					{Username: "alice", Role: MemberRoleOwner, Teams: []TeamMembership{{Name: "platform", Role: TeamRoleMaintainer}}},
 					{Username: "bob", Role: MemberRoleMember, Teams: []TeamMembership{{Name: "platform", Role: TeamRoleMaintainer}, {Name: "security-core"}}},
 					{Username: "carol", Role: MemberRoleMember},
 				},
 			},
 			protectedOwners: []string{"alice"},
 			wantErrors:      nil,
+		},
+		{
+			name: "owner given a plain member role in a team is rejected",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleOwner, Teams: []TeamMembership{{Name: "platform", Role: TeamRoleMember}}},
+				},
+			},
+			wantErrors: []string{
+				`member "alice" is an organisation owner, so team "platform" cannot use role "member": GitHub reports owners as maintainers of every team they belong to, so the plan would keep proposing this change without it ever taking effect`,
+			},
+		},
+		{
+			name: "owner with an omitted team role is rejected, since it defaults to member",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "alice", Role: MemberRoleOwner, Teams: []TeamMembership{{Name: "platform"}}},
+				},
+			},
+			wantErrors: []string{
+				`member "alice" is an organisation owner, so team "platform" needs role "maintainer": the role defaults to "member" when omitted, and GitHub reports owners as maintainers of every team they belong to, so the plan would keep proposing this change without it ever taking effect`,
+			},
+		},
+		{
+			name: "a plain member may hold either team role",
+			config: MembersConfig{
+				Members: []Member{
+					{Username: "bob", Role: MemberRoleMember, Teams: []TeamMembership{{Name: "platform", Role: TeamRoleMember}, {Name: "security-core"}}},
+				},
+			},
+			wantErrors: nil,
 		},
 		{
 			name: "duplicate username rejected",


### PR DESCRIPTION
Closes G-Research/gr-oss#1434

GitHub reports organisation owners as **maintainers of every team they belong to**, so a team
membership declaring the `member` role for an owner never settles:

1. apply reports success — `1 added, 0 changed, 1 destroyed`
2. GitHub keeps `maintainer`
3. the next plan, with no config change at all, proposes `1 to change` on that membership
4. repeats indefinitely

Nothing objected to it. The schema accepts either team role with no relationship to the
person's organisation role, and validation passed cleanly. The importer never generates this
shape — it reads `maintainer` from GitHub — so it only arises from editing `members.yaml` by
hand, which is the normal way to manage membership.

## Why it is worth a rule rather than a note

The damage is to trust in the plan. A workspace that never reaches "no changes" trains
reviewers to skim past `1 to change`, which is precisely the habit that makes a genuine
destroy easy to miss — on the plans that decide who belongs to the organisation.

Both facts live in the same file, so this needs no API call:

```yaml
- username: someone
  role: owner          # organisation role
  teams:
    - name: platform
      role: member     # cannot hold while the above is owner
```

## The omitted role counts too

`members.tf` reads a missing team role as `member`, and the importer omits it for plain
members. Leaving it out therefore produces exactly the same non-convergence as writing it, so
both are rejected — with different messages, since the cause differs:

| Config | Message |
|---|---|
| explicit `role: member` | `... cannot use role "member": ...` |
| role omitted | `... needs role "maintainer": the role defaults to "member" when omitted, ...` |

## Two existing fixtures had to change

Both encoded an owner with an omitted team role and asserted it was valid:

- `TestMembersConfigValidate` / "valid config with team member and maintainer roles"
- `TestValidateOrg_StagedMembersResolveAgainstPromotedTeams`

Changing existing tests to make a new rule pass is exactly how a mistake gets hidden, so it is
worth being explicit: the claim is that the **fixtures were wrong**, not the rule. The same
shape was observed producing a perpetual diff against a real organisation. Both now set the
role explicitly, which also makes them realistic — the importer always writes it.

That it was baked into two fixtures independently is itself a sign the constraint was not
known.

## Tests

Three cases added, including one asserting the rule does **not** over-reach: a plain member may
hold either team role.

Verified against the real configuration that produced the perpetual diff — it now fails at
`validate`, before the plan:

```
member "<owner>" is an organisation owner, so team "<team>" cannot use role "member": GitHub
reports owners as maintainers of every team they belong to, so the plan would keep proposing
this change without it ever taking effect
```

The organisation's current config still validates cleanly, since the importer wrote explicit
roles throughout.
